### PR TITLE
feat: T90-T94 UI改善・ユーティリティ整備

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "biome lint .",
     "format": "biome format --write .",
     "check": "biome check --write .",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage"
   },

--- a/src/app/admin/invitations/page.tsx
+++ b/src/app/admin/invitations/page.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { parseApiError } from "@/lib/apiError";
+
 type Invitation = {
   id: string;
   email: string | null;
@@ -46,7 +48,7 @@ export default function InvitationsPage() {
       setEmail("");
       loadInvitations();
     } else {
-      setError("招待リンクの発行に失敗しました。");
+      setError(await parseApiError(res, "招待リンクの発行に失敗しました。"));
     }
   }
 

--- a/src/app/admin/users/UserTable.tsx
+++ b/src/app/admin/users/UserTable.tsx
@@ -209,9 +209,15 @@ export function UserTable({
 
       {/* 削除確認ダイアログ */}
       {deleteDialog && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" aria-modal="true" role="dialog">
-          <div ref={dialogRef} className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-            <h2 className="mb-2 text-base font-bold text-zinc-900">ユーザーを削除</h2>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-dialog-title"
+            className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
+          >
+            <h2 id="delete-dialog-title" className="mb-2 text-base font-bold text-zinc-900">ユーザーを削除</h2>
             <p className="mb-4 text-sm text-zinc-600">
               <span className="font-medium text-zinc-900">{deleteDialog.userName}</span>{" "}
               を削除します。この操作は取り消せません。

--- a/src/app/admin/users/UserTable.tsx
+++ b/src/app/admin/users/UserTable.tsx
@@ -141,7 +141,7 @@ export function UserTable({
                             : "bg-green-50 text-green-700 hover:bg-green-100"
                         }`}
                       >
-                        {user.isActive ? "無効化" : "有効化"}
+                        {loading === `active-${user.id}` ? "更新中..." : user.isActive ? "無効化" : "有効化"}
                       </button>
                     )}
                     {user.id !== currentUserId && (
@@ -154,7 +154,7 @@ export function UserTable({
                         }}
                         className="rounded bg-red-50 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-100 disabled:opacity-50"
                       >
-                        削除
+                        {loading === `delete-${user.id}` ? "削除中..." : "削除"}
                       </button>
                     )}
                   </div>
@@ -200,7 +200,7 @@ export function UserTable({
                 onClick={handleDelete}
                 className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
               >
-                削除する
+                {loading === `delete-${deleteDialog.userId}` ? "削除中..." : "削除する"}
               </button>
             </div>
           </div>

--- a/src/app/admin/users/UserTable.tsx
+++ b/src/app/admin/users/UserTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type User = {
   id: string;
@@ -28,6 +28,48 @@ export function UserTable({
   const [deleteDialog, setDeleteDialog] = useState<DeleteDialog | null>(null);
   const [deleteNameInput, setDeleteNameInput] = useState("");
   const [deleteError, setDeleteError] = useState("");
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // モーダル表示時に input へ自動フォーカス
+  useEffect(() => {
+    if (deleteDialog) {
+      inputRef.current?.focus();
+    }
+  }, [deleteDialog]);
+
+  // ESC キーでダイアログを閉じる
+  useEffect(() => {
+    if (!deleteDialog) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setDeleteDialog(null);
+        setDeleteNameInput("");
+        setDeleteError("");
+      }
+      // フォーカストラップ: Tab キーをダイアログ内に限定
+      if (e.key === "Tab" && dialogRef.current) {
+        const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input, [tabindex]:not([tabindex="-1"])'
+        );
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [deleteDialog]);
 
   async function handleRoleChange(id: string, role: string) {
     setLoading(`role-${id}`);
@@ -167,8 +209,8 @@ export function UserTable({
 
       {/* 削除確認ダイアログ */}
       {deleteDialog && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" aria-modal="true" role="dialog">
+          <div ref={dialogRef} className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
             <h2 className="mb-2 text-base font-bold text-zinc-900">ユーザーを削除</h2>
             <p className="mb-4 text-sm text-zinc-600">
               <span className="font-medium text-zinc-900">{deleteDialog.userName}</span>{" "}
@@ -177,6 +219,7 @@ export function UserTable({
               確認のため、ユーザー名を入力してください。
             </p>
             <input
+              ref={inputRef}
               type="text"
               value={deleteNameInput}
               onChange={(e) => { setDeleteNameInput(e.target.value); setDeleteError(""); }}

--- a/src/app/reports/[id]/CommentForm.tsx
+++ b/src/app/reports/[id]/CommentForm.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 
 import { ErrorMessage } from "@/components/ErrorMessage";
+import { parseApiError } from "@/lib/apiError";
 
 type Props = {
   reportId: string;
@@ -29,7 +30,7 @@ export function CommentForm({ reportId }: Props) {
       });
 
       if (!res.ok) {
-        setError("コメントの投稿に失敗しました。入力内容を確認してください");
+        setError(await parseApiError(res, "コメントの投稿に失敗しました。入力内容を確認してください"));
       } else {
         formRef.current?.reset();
         router.refresh();

--- a/src/app/reports/[id]/edit/ReportEditForm.tsx
+++ b/src/app/reports/[id]/edit/ReportEditForm.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { ErrorMessage } from "@/components/ErrorMessage";
-import { parseApiError } from "@/lib/apiError";
+import { type FieldErrors, parseFieldErrors } from "@/lib/apiError";
 
 type Props = {
   id: string;
@@ -15,15 +15,24 @@ type Props = {
   };
 };
 
+const MAX_LENGTH = 5000;
+
 export function ReportEditForm({ id, defaultValues }: Props) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [pending, setPending] = useState(false);
+  const [counts, setCounts] = useState({
+    workContent: defaultValues.workContent.length,
+    tomorrowPlan: defaultValues.tomorrowPlan.length,
+    notes: defaultValues.notes.length,
+  });
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setPending(true);
     setError(null);
+    setFieldErrors({});
 
     const data = new FormData(e.currentTarget);
     try {
@@ -40,7 +49,9 @@ export function ReportEditForm({ id, defaultValues }: Props) {
       if (res.status === 403) {
         setError("この日報を編集する権限がありません");
       } else if (!res.ok) {
-        setError(await parseApiError(res, "保存に失敗しました。入力内容を確認してください"));
+        const parsed = await parseFieldErrors(res);
+        setError(parsed.message);
+        setFieldErrors(parsed.fieldErrors);
       } else {
         router.push(`/reports/${id}`);
         router.refresh();
@@ -63,11 +74,18 @@ export function ReportEditForm({ id, defaultValues }: Props) {
           id="workContent"
           name="workContent"
           required
-          maxLength={5000}
+          maxLength={MAX_LENGTH}
           rows={6}
           defaultValue={defaultValues.workContent}
           className="mt-1 block w-full rounded-md border border-zinc-300 px-3 py-2 text-sm shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+          onChange={(e) => setCounts((prev) => ({ ...prev, workContent: e.target.value.length }))}
         />
+        <p className={`mt-1 text-right text-xs ${counts.workContent > MAX_LENGTH * 0.9 ? "text-red-500" : "text-zinc-400"}`}>
+          {counts.workContent.toLocaleString()} / {MAX_LENGTH.toLocaleString()}
+        </p>
+        {fieldErrors.workContent?.[0] && (
+          <p className="text-xs text-red-600">{fieldErrors.workContent[0]}</p>
+        )}
       </div>
       <div>
         <label htmlFor="tomorrowPlan" className="block text-sm font-medium text-zinc-700">
@@ -77,11 +95,18 @@ export function ReportEditForm({ id, defaultValues }: Props) {
           id="tomorrowPlan"
           name="tomorrowPlan"
           required
-          maxLength={5000}
+          maxLength={MAX_LENGTH}
           rows={4}
           defaultValue={defaultValues.tomorrowPlan}
           className="mt-1 block w-full rounded-md border border-zinc-300 px-3 py-2 text-sm shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+          onChange={(e) => setCounts((prev) => ({ ...prev, tomorrowPlan: e.target.value.length }))}
         />
+        <p className={`mt-1 text-right text-xs ${counts.tomorrowPlan > MAX_LENGTH * 0.9 ? "text-red-500" : "text-zinc-400"}`}>
+          {counts.tomorrowPlan.toLocaleString()} / {MAX_LENGTH.toLocaleString()}
+        </p>
+        {fieldErrors.tomorrowPlan?.[0] && (
+          <p className="text-xs text-red-600">{fieldErrors.tomorrowPlan[0]}</p>
+        )}
       </div>
       <div>
         <label htmlFor="notes" className="block text-sm font-medium text-zinc-700">
@@ -91,11 +116,18 @@ export function ReportEditForm({ id, defaultValues }: Props) {
         <textarea
           id="notes"
           name="notes"
-          maxLength={5000}
+          maxLength={MAX_LENGTH}
           rows={3}
           defaultValue={defaultValues.notes}
           className="mt-1 block w-full rounded-md border border-zinc-300 px-3 py-2 text-sm shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+          onChange={(e) => setCounts((prev) => ({ ...prev, notes: e.target.value.length }))}
         />
+        <p className={`mt-1 text-right text-xs ${counts.notes > MAX_LENGTH * 0.9 ? "text-red-500" : "text-zinc-400"}`}>
+          {counts.notes.toLocaleString()} / {MAX_LENGTH.toLocaleString()}
+        </p>
+        {fieldErrors.notes?.[0] && (
+          <p className="text-xs text-red-600">{fieldErrors.notes[0]}</p>
+        )}
       </div>
       <div className="flex gap-3">
         <button

--- a/src/app/reports/[id]/edit/ReportEditForm.tsx
+++ b/src/app/reports/[id]/edit/ReportEditForm.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { ErrorMessage } from "@/components/ErrorMessage";
+import { parseApiError } from "@/lib/apiError";
 
 type Props = {
   id: string;
@@ -39,7 +40,7 @@ export function ReportEditForm({ id, defaultValues }: Props) {
       if (res.status === 403) {
         setError("この日報を編集する権限がありません");
       } else if (!res.ok) {
-        setError("保存に失敗しました。入力内容を確認してください");
+        setError(await parseApiError(res, "保存に失敗しました。入力内容を確認してください"));
       } else {
         router.push(`/reports/${id}`);
         router.refresh();

--- a/src/app/reports/daily/page.tsx
+++ b/src/app/reports/daily/page.tsx
@@ -1,17 +1,9 @@
 import Link from "next/link";
 
 import { getSession } from "@/lib/auth";
-import { isValidDate } from "@/lib/dateUtils";
+import { isValidDate, today } from "@/lib/dateUtils";
 import { prisma } from "@/lib/prisma";
 import { DailyFilter } from "./DailyFilter";
-
-function today(): string {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
 
 export default async function DailyViewPage({
   searchParams,

--- a/src/app/reports/monthly/page.tsx
+++ b/src/app/reports/monthly/page.tsx
@@ -1,25 +1,9 @@
 import Link from "next/link";
 
 import { getSession } from "@/lib/auth";
-import { isValidDate } from "@/lib/dateUtils";
+import { currentMonth, isValidDate, monthRange } from "@/lib/dateUtils";
 import { prisma } from "@/lib/prisma";
 import { MonthlyFilter } from "./MonthlyFilter";
-
-function currentMonth(): string {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  return `${year}-${month}`;
-}
-
-function monthRange(month: string): { from: string; to: string } {
-  const [year, mon] = month.split("-").map(Number);
-  const lastDay = new Date(year, mon, 0).getDate();
-  return {
-    from: `${month}-01`,
-    to: `${month}-${String(lastDay).padStart(2, "0")}`,
-  };
-}
 
 export default async function MonthlyViewPage({
   searchParams,

--- a/src/app/reports/new/ReportNewForm.tsx
+++ b/src/app/reports/new/ReportNewForm.tsx
@@ -4,18 +4,23 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { ErrorMessage } from "@/components/ErrorMessage";
-import { parseApiError } from "@/lib/apiError";
+import { type FieldErrors, parseFieldErrors } from "@/lib/apiError";
 import { today } from "@/lib/dateUtils";
+
+const MAX_LENGTH = 5000;
 
 export function ReportNewForm() {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [pending, setPending] = useState(false);
+  const [counts, setCounts] = useState({ workContent: 0, tomorrowPlan: 0, notes: 0 });
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setPending(true);
     setError(null);
+    setFieldErrors({});
 
     const data = new FormData(e.currentTarget);
     try {
@@ -33,7 +38,9 @@ export function ReportNewForm() {
       if (res.status === 409) {
         setError("この日付の日報はすでに作成済みです");
       } else if (!res.ok) {
-        setError(await parseApiError(res, "保存に失敗しました。入力内容を確認してください"));
+        const parsed = await parseFieldErrors(res);
+        setError(parsed.message);
+        setFieldErrors(parsed.fieldErrors);
       } else {
         const { id } = await res.json();
         router.push(`/reports/${id}`);
@@ -60,6 +67,9 @@ export function ReportNewForm() {
           defaultValue={today()}
           className="mt-1 block w-full rounded-md border border-zinc-300 px-3 py-2 text-sm shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
         />
+        {fieldErrors.date?.[0] && (
+          <p className="mt-1 text-xs text-red-600">{fieldErrors.date[0]}</p>
+        )}
       </div>
       <div>
         <label htmlFor="workContent" className="block text-sm font-medium text-zinc-700">
@@ -69,10 +79,17 @@ export function ReportNewForm() {
           id="workContent"
           name="workContent"
           required
-          maxLength={5000}
+          maxLength={MAX_LENGTH}
           rows={6}
           className="mt-1 block w-full rounded-md border border-zinc-300 px-3 py-2 text-sm shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+          onChange={(e) => setCounts((prev) => ({ ...prev, workContent: e.target.value.length }))}
         />
+        <p className={`mt-1 text-right text-xs ${counts.workContent > MAX_LENGTH * 0.9 ? "text-red-500" : "text-zinc-400"}`}>
+          {counts.workContent.toLocaleString()} / {MAX_LENGTH.toLocaleString()}
+        </p>
+        {fieldErrors.workContent?.[0] && (
+          <p className="text-xs text-red-600">{fieldErrors.workContent[0]}</p>
+        )}
       </div>
       <div>
         <label htmlFor="tomorrowPlan" className="block text-sm font-medium text-zinc-700">
@@ -82,10 +99,17 @@ export function ReportNewForm() {
           id="tomorrowPlan"
           name="tomorrowPlan"
           required
-          maxLength={5000}
+          maxLength={MAX_LENGTH}
           rows={4}
           className="mt-1 block w-full rounded-md border border-zinc-300 px-3 py-2 text-sm shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+          onChange={(e) => setCounts((prev) => ({ ...prev, tomorrowPlan: e.target.value.length }))}
         />
+        <p className={`mt-1 text-right text-xs ${counts.tomorrowPlan > MAX_LENGTH * 0.9 ? "text-red-500" : "text-zinc-400"}`}>
+          {counts.tomorrowPlan.toLocaleString()} / {MAX_LENGTH.toLocaleString()}
+        </p>
+        {fieldErrors.tomorrowPlan?.[0] && (
+          <p className="text-xs text-red-600">{fieldErrors.tomorrowPlan[0]}</p>
+        )}
       </div>
       <div>
         <label htmlFor="notes" className="block text-sm font-medium text-zinc-700">
@@ -95,10 +119,17 @@ export function ReportNewForm() {
         <textarea
           id="notes"
           name="notes"
-          maxLength={5000}
+          maxLength={MAX_LENGTH}
           rows={3}
           className="mt-1 block w-full rounded-md border border-zinc-300 px-3 py-2 text-sm shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+          onChange={(e) => setCounts((prev) => ({ ...prev, notes: e.target.value.length }))}
         />
+        <p className={`mt-1 text-right text-xs ${counts.notes > MAX_LENGTH * 0.9 ? "text-red-500" : "text-zinc-400"}`}>
+          {counts.notes.toLocaleString()} / {MAX_LENGTH.toLocaleString()}
+        </p>
+        {fieldErrors.notes?.[0] && (
+          <p className="text-xs text-red-600">{fieldErrors.notes[0]}</p>
+        )}
       </div>
       <div className="flex gap-3">
         <button

--- a/src/app/reports/new/ReportNewForm.tsx
+++ b/src/app/reports/new/ReportNewForm.tsx
@@ -4,14 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { ErrorMessage } from "@/components/ErrorMessage";
-
-function today(): string {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
+import { today } from "@/lib/dateUtils";
 
 export function ReportNewForm() {
   const router = useRouter();

--- a/src/app/reports/new/ReportNewForm.tsx
+++ b/src/app/reports/new/ReportNewForm.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { ErrorMessage } from "@/components/ErrorMessage";
+import { parseApiError } from "@/lib/apiError";
 import { today } from "@/lib/dateUtils";
 
 export function ReportNewForm() {
@@ -32,7 +33,7 @@ export function ReportNewForm() {
       if (res.status === 409) {
         setError("この日付の日報はすでに作成済みです");
       } else if (!res.ok) {
-        setError("保存に失敗しました。入力内容を確認してください");
+        setError(await parseApiError(res, "保存に失敗しました。入力内容を確認してください"));
       } else {
         const { id } = await res.json();
         router.push(`/reports/${id}`);

--- a/src/app/settings/SettingsForm.tsx
+++ b/src/app/settings/SettingsForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ErrorMessage } from "@/components/ErrorMessage";
+import { parseApiError } from "@/lib/apiError";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -34,8 +35,7 @@ export function SettingsForm({ initialName, email }: Props) {
         setNameSuccess(true);
         router.refresh();
       } else {
-        const json = await res.json().catch(() => ({}));
-        setNameError(json.error ?? "名前の更新に失敗しました");
+        setNameError(await parseApiError(res, "名前の更新に失敗しました"));
       }
     } catch {
       setNameError("通信エラーが発生しました");

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -10,20 +10,31 @@ type Props = {
 export function SignOutButton({ className }: Props) {
   const { signOut } = useClerk();
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function handleSignOut() {
     setLoading(true);
-    await signOut({ redirectUrl: "/login" });
+    setError(null);
+    try {
+      await signOut({ redirectUrl: "/login" });
+    } catch {
+      setError("ログアウトに失敗しました。時間をおいて再度お試しください");
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
-    <button
-      type="button"
-      disabled={loading}
-      onClick={handleSignOut}
-      className={className}
-    >
-      {loading ? "ログアウト中..." : "ログアウト"}
-    </button>
+    <div>
+      {error && <p className="text-xs text-red-600">{error}</p>}
+      <button
+        type="button"
+        disabled={loading}
+        onClick={handleSignOut}
+        className={className}
+      >
+        {loading ? "ログアウト中..." : "ログアウト"}
+      </button>
+    </div>
   );
 }

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -1,18 +1,29 @@
 "use client";
 
-import { SignOutButton as ClerkSignOutButton } from "@clerk/nextjs";
+import { useClerk } from "@clerk/nextjs";
+import { useState } from "react";
 
 type Props = {
   className?: string;
-  children?: React.ReactNode;
 };
 
-export function SignOutButton({ className, children = "ログアウト" }: Props) {
+export function SignOutButton({ className }: Props) {
+  const { signOut } = useClerk();
+  const [loading, setLoading] = useState(false);
+
+  async function handleSignOut() {
+    setLoading(true);
+    await signOut({ redirectUrl: "/login" });
+  }
+
   return (
-    <ClerkSignOutButton redirectUrl="/login">
-      <button type="button" className={className}>
-        {children}
-      </button>
-    </ClerkSignOutButton>
+    <button
+      type="button"
+      disabled={loading}
+      onClick={handleSignOut}
+      className={className}
+    >
+      {loading ? "ログアウト中..." : "ログアウト"}
+    </button>
   );
 }

--- a/src/lib/apiError.test.ts
+++ b/src/lib/apiError.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { parseApiError } from "./apiError";
+
+function makeResponse(body: unknown, status = 400): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeInvalidJsonResponse(): Response {
+  return new Response("not json", {
+    status: 400,
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+
+describe("parseApiError", () => {
+  it("正常系: { error: string } 形式のレスポンスからエラー文字列を返す", async () => {
+    const res = makeResponse({ error: "名前が空です" });
+    expect(await parseApiError(res, "fallback")).toBe("名前が空です");
+  });
+
+  it("正常系: error が文字列でない場合（flatten形式）は fallback を返す", async () => {
+    const res = makeResponse({
+      error: { formErrors: [], fieldErrors: { date: ["必須です"] } },
+    });
+    expect(await parseApiError(res, "fallback")).toBe("fallback");
+  });
+
+  it("正常系: JSON パースに失敗した場合は fallback を返す", async () => {
+    const res = makeInvalidJsonResponse();
+    expect(await parseApiError(res, "fallback")).toBe("fallback");
+  });
+
+  it("正常系: error キーが存在しない場合は fallback を返す", async () => {
+    const res = makeResponse({ message: "something" });
+    expect(await parseApiError(res, "fallback")).toBe("fallback");
+  });
+
+  it("正常系: 空オブジェクトの場合は fallback を返す", async () => {
+    const res = makeResponse({});
+    expect(await parseApiError(res, "fallback")).toBe("fallback");
+  });
+});

--- a/src/lib/apiError.test.ts
+++ b/src/lib/apiError.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 
-import { parseApiError } from "./apiError";
+import { parseApiError, parseFieldErrors } from "./apiError";
 
 function makeResponse(body: unknown, status = 400): Response {
   return new Response(JSON.stringify(body), {
@@ -43,5 +43,46 @@ describe("parseApiError", () => {
   it("正常系: 空オブジェクトの場合は fallback を返す", async () => {
     const res = makeResponse({});
     expect(await parseApiError(res, "fallback")).toBe("fallback");
+  });
+});
+
+describe("parseFieldErrors", () => {
+  it("正常系: flatten 形式のフィールドエラーを返す", async () => {
+    const res = makeResponse({
+      error: { formErrors: [], fieldErrors: { date: ["必須です"], workContent: ["長すぎます"] } },
+    });
+    const result = await parseFieldErrors(res);
+    expect(result.fieldErrors).toEqual({ date: ["必須です"], workContent: ["長すぎます"] });
+    expect(result.message).toBe("必須です");
+  });
+
+  it("正常系: formErrors がある場合はその先頭をメッセージに使う", async () => {
+    const res = makeResponse({
+      error: { formErrors: ["フォームエラー"], fieldErrors: {} },
+    });
+    const result = await parseFieldErrors(res);
+    expect(result.message).toBe("フォームエラー");
+    expect(result.fieldErrors).toEqual({});
+  });
+
+  it("正常系: { error: string } 形式の場合は message にセットし fieldErrors は空", async () => {
+    const res = makeResponse({ error: "権限がありません" });
+    const result = await parseFieldErrors(res);
+    expect(result.message).toBe("権限がありません");
+    expect(result.fieldErrors).toEqual({});
+  });
+
+  it("正常系: JSON パース失敗時はデフォルトメッセージで fieldErrors は空", async () => {
+    const res = makeInvalidJsonResponse();
+    const result = await parseFieldErrors(res);
+    expect(result.message).toBe("入力内容を確認してください");
+    expect(result.fieldErrors).toEqual({});
+  });
+
+  it("正常系: formErrors・fieldErrors ともに空の場合はデフォルトメッセージ", async () => {
+    const res = makeResponse({ error: { formErrors: [], fieldErrors: {} } });
+    const result = await parseFieldErrors(res);
+    expect(result.message).toBe("入力内容を確認してください");
+    expect(result.fieldErrors).toEqual({});
   });
 });

--- a/src/lib/apiError.ts
+++ b/src/lib/apiError.ts
@@ -8,3 +8,33 @@ export async function parseApiError(res: Response, fallback: string): Promise<st
   if (typeof json.error === "string") return json.error;
   return fallback;
 }
+
+export type FieldErrors = Record<string, string[]>;
+
+type ParsedFieldErrors = {
+  message: string;
+  fieldErrors: FieldErrors;
+};
+
+/**
+ * API レスポンスから flatten 形式のフィールドエラーを取り出す。
+ * - `{ error: { formErrors, fieldErrors } }` 形式 → フィールドエラーを返す
+ * - `{ error: string }` 形式 → message にセットし fieldErrors は空
+ * - JSON パース失敗・形式不一致 → デフォルトメッセージで fieldErrors は空
+ */
+export async function parseFieldErrors(res: Response): Promise<ParsedFieldErrors> {
+  const json = await res.json().catch(() => ({}));
+  if (typeof json.error === "string") {
+    return { message: json.error, fieldErrors: {} };
+  }
+  if (typeof json.error === "object" && json.error !== null) {
+    const flat = json.error as { formErrors?: string[]; fieldErrors?: Record<string, string[]> };
+    const fieldErrors = flat.fieldErrors ?? {};
+    const message =
+      flat.formErrors?.[0] ??
+      Object.values(fieldErrors).flat()[0] ??
+      "入力内容を確認してください";
+    return { message, fieldErrors };
+  }
+  return { message: "入力内容を確認してください", fieldErrors: {} };
+}

--- a/src/lib/apiError.ts
+++ b/src/lib/apiError.ts
@@ -1,0 +1,10 @@
+/**
+ * API レスポンスからエラーメッセージを取り出す。
+ * - `{ error: string }` 形式 → そのまま返す
+ * - JSON パース失敗・形式不一致 → fallback を返す
+ */
+export async function parseApiError(res: Response, fallback: string): Promise<string> {
+  const json = await res.json().catch(() => ({}));
+  if (typeof json.error === "string") return json.error;
+  return fallback;
+}

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { isValidDate, isValidMonth, startOfTodayUtc } from "./dateUtils";
+import { currentMonth, isValidDate, isValidMonth, monthRange, startOfTodayUtc, today } from "./dateUtils";
 
 describe("startOfTodayUtc", () => {
   it("正常系: 時刻が UTC 00:00:00.000 であること", () => {
@@ -42,6 +42,59 @@ describe("isValidDate", () => {
     expect(isValidDate("2025-04-31")).toBe(false); // 4月31日
     expect(isValidDate("2025-13-01")).toBe(false); // 13月
     expect(isValidDate("2025-00-01")).toBe(false); // 0月
+  });
+});
+
+describe("today", () => {
+  it("正常系: YYYY-MM-DD 形式を返す", () => {
+    const result = today();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("正常系: 今日の年月日と一致する", () => {
+    const now = new Date();
+    const result = today();
+    const [year, month, day] = result.split("-").map(Number);
+    expect(year).toBe(now.getFullYear());
+    expect(month).toBe(now.getMonth() + 1);
+    expect(day).toBe(now.getDate());
+  });
+});
+
+describe("currentMonth", () => {
+  it("正常系: YYYY-MM 形式を返す", () => {
+    const result = currentMonth();
+    expect(result).toMatch(/^\d{4}-\d{2}$/);
+  });
+
+  it("正常系: 今月の年月と一致する", () => {
+    const now = new Date();
+    const result = currentMonth();
+    const [year, month] = result.split("-").map(Number);
+    expect(year).toBe(now.getFullYear());
+    expect(month).toBe(now.getMonth() + 1);
+  });
+});
+
+describe("monthRange", () => {
+  it("正常系: 月初・月末の日付範囲を返す（1月）", () => {
+    expect(monthRange("2025-01")).toEqual({ from: "2025-01-01", to: "2025-01-31" });
+  });
+
+  it("正常系: 月初・月末の日付範囲を返す（2月・平年）", () => {
+    expect(monthRange("2025-02")).toEqual({ from: "2025-02-01", to: "2025-02-28" });
+  });
+
+  it("正常系: 月初・月末の日付範囲を返す（2月・閏年）", () => {
+    expect(monthRange("2024-02")).toEqual({ from: "2024-02-01", to: "2024-02-29" });
+  });
+
+  it("正常系: 月初・月末の日付範囲を返す（12月）", () => {
+    expect(monthRange("2025-12")).toEqual({ from: "2025-12-01", to: "2025-12-31" });
+  });
+
+  it("正常系: 月末日が正しくゼロ埋めされる（4月）", () => {
+    expect(monthRange("2025-04")).toEqual({ from: "2025-04-01", to: "2025-04-30" });
   });
 });
 

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { currentMonth, isValidDate, isValidMonth, monthRange, startOfTodayUtc, today } from "./dateUtils";
 
@@ -46,18 +46,22 @@ describe("isValidDate", () => {
 });
 
 describe("today", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T10:00:00"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("正常系: YYYY-MM-DD 形式を返す", () => {
     const result = today();
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
   it("正常系: 今日の年月日と一致する", () => {
-    const now = new Date();
     const result = today();
-    const [year, month, day] = result.split("-").map(Number);
-    expect(year).toBe(now.getFullYear());
-    expect(month).toBe(now.getMonth() + 1);
-    expect(day).toBe(now.getDate());
+    expect(result).toBe("2025-06-15");
   });
 });
 

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -66,17 +66,22 @@ describe("today", () => {
 });
 
 describe("currentMonth", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T10:00:00"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("正常系: YYYY-MM 形式を返す", () => {
     const result = currentMonth();
     expect(result).toMatch(/^\d{4}-\d{2}$/);
   });
 
   it("正常系: 今月の年月と一致する", () => {
-    const now = new Date();
     const result = currentMonth();
-    const [year, month] = result.split("-").map(Number);
-    expect(year).toBe(now.getFullYear());
-    expect(month).toBe(now.getMonth() + 1);
+    expect(result).toBe("2025-06");
   });
 });
 

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -20,3 +20,30 @@ export function isValidMonth(value: string): boolean {
   const mon = Number(value.split("-")[1]);
   return mon >= 1 && mon <= 12;
 }
+
+/** 今日の日付を YYYY-MM-DD 形式で返す（ローカル時刻基準） */
+export function today(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/** 今月を YYYY-MM 形式で返す（ローカル時刻基準） */
+export function currentMonth(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+/** YYYY-MM 形式の月から月初・月末の日付範囲を返す */
+export function monthRange(month: string): { from: string; to: string } {
+  const [year, mon] = month.split("-").map(Number);
+  const lastDay = new Date(year, mon, 0).getDate();
+  return {
+    from: `${month}-01`,
+    to: `${month}-${String(lastDay).padStart(2, "0")}`,
+  };
+}


### PR DESCRIPTION
## Summary

- **T90**: ローディング状態の追加（UserTable・SignOutButton）
- **T91**: 日付ユーティリティを `dateUtils.ts` に集約
- **T92**: フォームエラーハンドリングを `parseApiError` で統一
- **T93**: 削除確認ダイアログにキーボードアクセシビリティ追加（ESCキー・フォーカストラップ）
- **T94**: バリデーションエラーのフィールド単位表示・文字数カウンター追加
- **chore**: `test` スクリプトを `vitest run` に修正、`test:watch` を追加

## Test plan

- [ ] `npm test` で全テストが通ることを確認
- [ ] 日報新規作成画面でローディング・フィールドエラー・文字数カウンターが動作する
- [ ] 日報編集画面で同様の動作確認
- [ ] 削除確認ダイアログでESCキー・Tabキーが機能する
- [ ] ログアウトボタンが「ログアウト中...」表示になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)