### PR TITLE
[T117] MOCK_USER_EMAIL サポートと未存在ユーザー時の挙動整備

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# .env.example — .env.local のテンプレート
+# このファイルをコピーして .env.local を作成し、実際の値を設定してください
+# cp .env.example .env.local
+
+# Neon PostgreSQL
+# 接続プール URL（アプリ実行時に使用）
+DATABASE_URL="postgresql://<user>:<password>@<host>-pooler.<region>.aws.neon.tech/<db>?sslmode=require&channel_binding=require&pgbouncer=true&connection_limit=1"
+# 直接接続 URL（prisma migrate 用）
+DIRECT_URL="postgresql://<user>:<password>@<host>.<region>.aws.neon.tech/<db>?sslmode=require&channel_binding=require"
+
+# Clerk（https://dashboard.clerk.com から取得）
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxx
+CLERK_SECRET_KEY=sk_test_xxx
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login
+NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/reports/daily
+
+# ローカル開発用モック（Clerk をバイパスして DB ユーザーを直接使用）
+# MOCK_USER_ID と MOCK_USER_EMAIL は同時に設定しない（MOCK_USER_ID が優先される）
+# 対象ユーザーが DB に存在しない場合は console.error が出力され getSession() は null を返す
+# MOCK_USER_ID=<DB の users.id>
+# MOCK_USER_EMAIL=<DB の users.email>

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,14 +84,16 @@ daily-hub/
 未認証ユーザー
   → proxy.ts（clerkMiddleware）でセッション確認
   → 未認証なら /login にリダイレクト（Clerk が処理）
-  → MOCK_USER_ID が設定されている場合はバイパス（ローカル開発用）
+  → MOCK_USER_ID / MOCK_USER_EMAIL が設定されている場合はバイパス（ローカル開発用）
 
 ログイン
   → Clerk の SignIn UI（/login）でメール+パスワード認証
   → Clerk がセッション Cookie を発行
 
 getSession()（src/lib/auth.ts）
-  → MOCK_USER_ID 環境変数が設定されている場合は DB ユーザーを直接返す
+  → MOCK_USER_ID 環境変数が設定されている場合は id で DB ユーザーを直接返す
+  → MOCK_USER_EMAIL 環境変数が設定されている場合は email で DB ユーザーを直接返す
+  → どちらも対象ユーザーが DB に存在しない場合は console.error を出力し null を返す
   → Clerk auth() で userId（clerkId）を取得
   → clerkId で DB ユーザーを検索
   → 未ヒット時：Clerk currentUser() でメールを取得し DB ユーザーと突合
@@ -176,7 +178,10 @@ NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login
 NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/reports/daily
 
 # ローカル開発用モック（Clerk をバイパスして DB ユーザーを直接使用）
+# MOCK_USER_ID と MOCK_USER_EMAIL は同時に設定しない（MOCK_USER_ID が優先）
+# 対象ユーザーが DB に存在しない場合は console.error を出力し getSession() は null を返す
 MOCK_USER_ID=<DB の users.id>
+# MOCK_USER_EMAIL=<DB の users.email>
 ```
 
 ## Prisma 7 の接続構成

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -28,7 +28,8 @@
 ```
 クライアント → リクエスト
   → getSession() を呼び出し
-    → MOCK_USER_ID が設定されている場合（非本番）: DB から直接返す
+    → MOCK_USER_ID が設定されている場合（非本番）: id で DB を検索して直接返す（未存在なら console.error + null）
+    → MOCK_USER_EMAIL が設定されている場合（非本番）: email で DB を検索して直接返す（未存在なら console.error + null）
     → Clerk の auth() で userId を取得
     → userId で DB の clerkId を検索
     → 未ヒット: メールで突合し clerkId を自動紐付け（初回ログイン）
@@ -114,7 +115,8 @@ const userId = session?.user?.id;
 | `CLERK_SECRET_KEY` | Clerk のシークレットキー |
 | `NEXT_PUBLIC_CLERK_SIGN_IN_URL` | サインイン URL（`/login`） |
 | `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL` | サインイン後のデフォルトリダイレクト先 |
-| `MOCK_USER_ID` | 非本番環境でのモックユーザー ID（Clerk をバイパス） |
+| `MOCK_USER_ID` | 非本番環境でのモックユーザー ID（Clerk をバイパス。対象未存在時は `console.error` + `null`） |
+| `MOCK_USER_EMAIL` | 非本番環境でのモックユーザーメール（Clerk をバイパス。`MOCK_USER_ID` と同時設定不可、ID 優先。対象未存在時は `console.error` + `null`） |
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,7 +28,10 @@ NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login
 NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/reports/daily
 
 # ローカル開発用モック（Clerk をバイパスして DB ユーザーを直接使用）
+# MOCK_USER_ID と MOCK_USER_EMAIL は同時に設定しない（MOCK_USER_ID が優先される）
+# 対象ユーザーが DB に存在しない場合は console.error が出力され getSession() は null を返す
 MOCK_USER_ID=<DB の users.id>
+# MOCK_USER_EMAIL=<DB の users.email>
 ```
 
 ### 設定済み MCP サーバー

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -61,13 +61,16 @@ describe("getSession", () => {
       });
     });
 
-    it("MOCK_USER_ID に対応する DB ユーザーが存在しない場合は null を返す", async () => {
+    it("MOCK_USER_ID に対応する DB ユーザーが存在しない場合は console.error を出力し null を返す", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       // @ts-expect-error
       mockFindUnique.mockResolvedValue(null);
 
       const result = await getSession();
       expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("MOCK_USER_ID"));
       expect(mockAuth).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
 
     it("MOCK_USER_ID ユーザーが isActive=false かつ redirectOnInactive=true のとき /auth-error?reason=inactive にリダイレクトする", async () => {
@@ -81,6 +84,62 @@ describe("getSession", () => {
     it("MOCK_USER_ID ユーザーが isActive=false かつ redirectOnInactive=false（デフォルト）のとき null を返す", async () => {
       // @ts-expect-error
       mockFindUnique.mockResolvedValue({ id: "mock-user-id", name: "無効ユーザー", role: "MEMBER", isActive: false });
+
+      const result = await getSession();
+      expect(result).toBeNull();
+      expect(mockAuth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("MOCK_USER_EMAIL モード（非本番環境）", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv, NODE_ENV: "development", MOCK_USER_EMAIL: "mock@example.com" };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it("MOCK_USER_EMAIL に対応する DB ユーザーのセッションを返す", async () => {
+      // @ts-expect-error
+      mockFindUnique.mockResolvedValue({ id: "user-uuid", name: "モックユーザー", role: "MEMBER", isActive: true });
+
+      const result = await getSession();
+      expect(result).toEqual({
+        user: { id: "user-uuid", name: "モックユーザー", role: "MEMBER", isActive: true },
+      });
+      expect(mockAuth).not.toHaveBeenCalled();
+      expect(mockFindUnique).toHaveBeenCalledWith({
+        where: { email: "mock@example.com" },
+        select: { id: true, name: true, role: true, isActive: true },
+      });
+    });
+
+    it("MOCK_USER_EMAIL に対応する DB ユーザーが存在しない場合は console.error を出力し null を返す", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      // @ts-expect-error
+      mockFindUnique.mockResolvedValue(null);
+
+      const result = await getSession();
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("MOCK_USER_EMAIL"));
+      expect(mockAuth).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it("MOCK_USER_EMAIL ユーザーが isActive=false かつ redirectOnInactive=true のとき /auth-error?reason=inactive にリダイレクトする", async () => {
+      // @ts-expect-error
+      mockFindUnique.mockResolvedValue({ id: "user-uuid", name: "無効ユーザー", role: "MEMBER", isActive: false });
+
+      await expect(getSession({ redirectOnInactive: true })).rejects.toThrow("NEXT_REDIRECT:/auth-error?reason=inactive");
+      expect(mockAuth).not.toHaveBeenCalled();
+    });
+
+    it("MOCK_USER_EMAIL ユーザーが isActive=false かつ redirectOnInactive=false（デフォルト）のとき null を返す", async () => {
+      // @ts-expect-error
+      mockFindUnique.mockResolvedValue({ id: "user-uuid", name: "無効ユーザー", role: "MEMBER", isActive: false });
 
       const result = await getSession();
       expect(result).toBeNull();

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,18 +16,39 @@ export type Session = {
 export async function getSession(options?: { redirectOnInactive?: boolean }): Promise<Session | null> {
   const redirectOnInactive = options?.redirectOnInactive ?? false;
 
-  // 非本番環境: MOCK_USER_ID が設定されている場合は DB から直接セッションを返す
-  if (process.env.NODE_ENV !== "production" && process.env.MOCK_USER_ID) {
-    const user = await prisma.user.findUnique({
-      where: { id: process.env.MOCK_USER_ID },
-      select: { id: true, name: true, role: true, isActive: true },
-    });
-    if (!user) return null;
-    if (!user.isActive) {
-      if (redirectOnInactive) redirect("/auth-error?reason=inactive");
-      return null;
+  // 非本番環境: MOCK_USER_ID / MOCK_USER_EMAIL が設定されている場合は DB から直接セッションを返す
+  if (process.env.NODE_ENV !== "production") {
+    if (process.env.MOCK_USER_ID) {
+      const user = await prisma.user.findUnique({
+        where: { id: process.env.MOCK_USER_ID },
+        select: { id: true, name: true, role: true, isActive: true },
+      });
+      if (!user) {
+        console.error(`[MOCK] MOCK_USER_ID="${process.env.MOCK_USER_ID}" に対応するユーザーが DB に存在しません`);
+        return null;
+      }
+      if (!user.isActive) {
+        if (redirectOnInactive) redirect("/auth-error?reason=inactive");
+        return null;
+      }
+      return { user };
     }
-    return { user };
+
+    if (process.env.MOCK_USER_EMAIL) {
+      const user = await prisma.user.findUnique({
+        where: { email: process.env.MOCK_USER_EMAIL },
+        select: { id: true, name: true, role: true, isActive: true },
+      });
+      if (!user) {
+        console.error(`[MOCK] MOCK_USER_EMAIL="${process.env.MOCK_USER_EMAIL}" に対応するユーザーが DB に存在しません`);
+        return null;
+      }
+      if (!user.isActive) {
+        if (redirectOnInactive) redirect("/auth-error?reason=inactive");
+        return null;
+      }
+      return { user };
+    }
   }
 
   const { userId } = await auth();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,8 +4,8 @@ import { NextResponse } from "next/server";
 const isPublicRoute = createRouteMatcher(["/login(.*)", "/auth-error"]);
 
 export default clerkMiddleware(async (auth, request) => {
-  // 非本番環境: MOCK_USER_ID が設定されている場合はバイパス
-  if (process.env.NODE_ENV !== "production" && process.env.MOCK_USER_ID) {
+  // 非本番環境: MOCK_USER_ID / MOCK_USER_EMAIL が設定されている場合はバイパス
+  if (process.env.NODE_ENV !== "production" && (process.env.MOCK_USER_ID || process.env.MOCK_USER_EMAIL)) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary

- `MOCK_USER_EMAIL` 環境変数を新規サポート（`email` で DB 検索して `getSession()` を返す）
- `MOCK_USER_ID` / `MOCK_USER_EMAIL` が設定されているのに対象ユーザーが DB に存在しない場合、`console.error` を出力し `null` を返す（設定ミスの早期検出）
- `proxy.ts` のバイパス条件に `MOCK_USER_EMAIL` を追加
- `docs/architecture.md` / `docs/auth.md` / `docs/development.md` に挙動を明記

Closes #101

## Test plan

- [x] `npx vitest run src/lib/auth.test.ts` — 18 tests passed
- [ ] `MOCK_USER_EMAIL` を `.env.local` に設定してアプリ起動、対象ユーザーでログインできるか確認
- [ ] 存在しない ID / Email を設定した場合に `console.error` が出力されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)