### PR TITLE
[T127] proxy.ts + Clerk dev browser 非互換の既知不具合を記録

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,11 +240,15 @@ git push origin master
 
 **本番環境での影響：** なし（Vercel 本番環境は dev browser チェックが存在しない）
 
-**回避策：** `.env.local` に以下を設定することで Clerk 認証をバイパスできる
+**回避策：** `.env.local` に以下のいずれか1つを設定することで Clerk 認証をバイパスできる
 
-```
+> **注意:** `MOCK_USER_ID` と `MOCK_USER_EMAIL` は同時に設定しないこと。両方設定した場合は `MOCK_USER_ID` が優先される。
+
+```env
+# どちらか片方のみ設定
 MOCK_USER_ID=<DBのユーザーID>
-MOCK_USER_EMAIL=<DBのメールアドレス>
+# または
+# MOCK_USER_EMAIL=<DBのメールアドレス>
 ```
 
 **E2E テスト（Playwright）での対応：** `MOCK_USER_ID` または `MOCK_USER_EMAIL` を設定した状態でテストを実行すること（`prisma/seed.ts` のシードデータに含まれるユーザーを使用）

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,6 +217,39 @@ git push origin master
 | ライブラリ | 事象 | 正しい仕様 |
 |-----------|------|-----------|
 | Next.js 16 | `src/proxy.ts` を `middleware.ts` に変更するよう指摘される | Next.js 16 以降、Middleware は Proxy に改称され `proxy.ts` が公式ファイル名となった。変更不要（[公式ドキュメント](https://nextjs.org/docs/app/getting-started/proxy)） |
+| Next.js 16 + `@clerk/nextjs` v7 | 開発環境の初回ブラウザアクセス時に全ルートが 404 になる（T127） | **既知の不具合。Clerk 側の対応待ち。** `proxy.ts` は Node.js runtime で動作するが、`clerkMiddleware` は Edge Runtime 向けに設計されており、dev browser トークン未設定時の handshake リダイレクトが正しく処理されない。本番環境では発生しない（dev browser チェックが存在しないため）。ローカル開発・E2E テストでは `.env.local` に `MOCK_USER_ID` または `MOCK_USER_EMAIL` を設定して Clerk 認証をバイパスすること。 |
+
+---
+
+## 既知の不具合
+
+### [T127] 開発環境の初回ブラウザアクセスで 404 になる
+
+**影響範囲：** `npm run dev` 起動後、Clerk dev browser cookie が未設定の状態でブラウザからページにアクセスしたとき
+
+**発生条件（3条件の AND）：**
+1. 開発環境（`NODE_ENV=development`）
+2. Clerk dev browser cookie 未設定（初回アクセス・Cookie クリア後）
+3. ブラウザのナビゲーションリクエスト（`Sec-Fetch-Dest: document`）
+
+**根本原因：**
+- `proxy.ts` は Node.js runtime で動作する（Next.js 16 の新機能）
+- `@clerk/nextjs` の `clerkMiddleware` は Edge Runtime（`middleware.ts`）向けに実装されており、`proxy.ts` では dev browser handshake フローが正しく処理されない
+- dev browser missing 検出 → Clerk FAPI へのハンドシェイクリダイレクト → `proxy.ts` でリダイレクトが正しく処理されず `/clerk_XXXX` へリライト → 404
+- Clerk 公式 Issue にて `proxy.ts`（Node.js runtime）の完全対応は未完了（[clerk/javascript#7705](https://github.com/clerk/javascript/issues/7705) は用語変更のみ）
+
+**本番環境での影響：** なし（Vercel 本番環境は dev browser チェックが存在しない）
+
+**回避策：** `.env.local` に以下を設定することで Clerk 認証をバイパスできる
+
+```
+MOCK_USER_ID=<DBのユーザーID>
+MOCK_USER_EMAIL=<DBのメールアドレス>
+```
+
+**E2E テスト（Playwright）での対応：** `MOCK_USER_ID` または `MOCK_USER_EMAIL` を設定した状態でテストを実行すること（`prisma/seed.ts` のシードデータに含まれるユーザーを使用）
+
+**対応方針：** Clerk 側の `proxy.ts` 対応完了後に回避策を削除する
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,7 +217,7 @@ git push origin master
 | ライブラリ | 事象 | 正しい仕様 |
 |-----------|------|-----------|
 | Next.js 16 | `src/proxy.ts` を `middleware.ts` に変更するよう指摘される | Next.js 16 以降、Middleware は Proxy に改称され `proxy.ts` が公式ファイル名となった。変更不要（[公式ドキュメント](https://nextjs.org/docs/app/getting-started/proxy)） |
-| Next.js 16 + `@clerk/nextjs` v7 | 開発環境の初回ブラウザアクセス時に全ルートが 404 になる（T127） | **既知の不具合。Clerk 側の対応待ち。** `proxy.ts` は Node.js runtime で動作するが、`clerkMiddleware` は Edge Runtime 向けに設計されており、dev browser トークン未設定時の handshake リダイレクトが正しく処理されない。本番環境では発生しない（dev browser チェックが存在しないため）。ローカル開発・E2E テストでは `.env.local` に `MOCK_USER_ID` または `MOCK_USER_EMAIL` を設定して Clerk 認証をバイパスすること。 |
+| Next.js 16 + `@clerk/nextjs` v7 | 開発環境の初回ブラウザアクセス時に全ルートが 404 になる（T127） | **既知の不具合。詳細は [T127](#t127-開発環境の初回ブラウザアクセスで-404-になる) を参照。** |
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,6 +65,53 @@ vi.mock("@/lib/prisma", () => ({
 
 ---
 
+## E2E テスト（Playwright MCP）
+
+### 制約：T127 Clerk dev browser 問題
+
+開発環境では `proxy.ts`（Node.js runtime）と `@clerk/nextjs` の `clerkMiddleware`（Edge Runtime 向け設計）の非互換により、**Clerk dev browser cookie 未設定の初回ブラウザアクセスが 404 になる**（Clerk 側の対応待ち）。
+
+そのため、E2E テストでは `MOCK_USER_EMAIL` を使って Clerk 認証をバイパスする。
+
+| テストの種類 | MOCK の要否 |
+|------------|------------|
+| 機能テスト・ロールベースのシナリオ | MOCK 使用 |
+| isActive=false の挙動（sunagimo） | MOCK 使用（代替可能） |
+| 実際の Clerk ログイン・ログアウトフロー | T127 解消まで自動テスト対象外 |
+| 未ログイン → /login リダイレクト | T127 解消まで自動テスト対象外 |
+
+### テストユーザー（`prisma/seed.ts` のシードデータ）
+
+| メール | ロール | isActive | 主な用途 |
+|--------|--------|----------|---------|
+| `bonjiri@example.com` | ADMIN | true | 管理画面の操作確認 |
+| `tsukune@example.com` | MEMBER | true | 日報・コメントのメインユーザー |
+| `tebasaki@example.com` | MEMBER | true | ユーザー分離テスト |
+| `nankotsu@example.com` | VIEWER | true | VIEWER 制限の確認 |
+| `sunagimo@example.com` | MEMBER | false | isActive=false のリダイレクト確認 |
+| `torikawa@example.com` | MEMBER | true | 管理画面での操作対象 |
+
+### Playwright MCP への指示例
+
+```
+以下の手順で E2E テストを実施してください。
+
+## 事前準備
+1. `npx tsx prisma/seed.ts` を実行してテストデータを初期化する
+2. `.env.local` の `MOCK_USER_EMAIL` にテストユーザーのメールアドレスを設定する
+3. `npm run dev` でサーバーを起動する（ポート: 3000）
+
+## 制約
+- Clerk dev browser の既知バグ（T127）により、MOCK_USER_EMAIL を必ず設定すること
+- MOCK_USER_EMAIL を設定した状態では Clerk の実認証フロー・未ログイン挙動は確認できない
+- テストユーザーを切り替える場合は .env.local を書き換えてサーバーを再起動すること
+
+## テスト対象
+docs/e2e-scenarios.md の [テストしたいセクション名] を参照してテストを実施してください。
+```
+
+---
+
 ## テストデータ投入（Seed）
 
 ### 概要


### PR DESCRIPTION
## 概要

`proxy.ts`（Node.js runtime）と `@clerk/nextjs` v7 の `clerkMiddleware`（Edge Runtime 向け設計）の非互換による既知不具合（T127）をドキュメントに記録する。

コード変更なし。Clerk 側の対応完了まで Issue #119 をオープンのまま維持する。

## 変更内容

### `docs/architecture.md`
- 「既知の不具合」セクションを新設
- 発生条件（開発環境 / dev browser cookie 未設定 / ブラウザナビゲーション）を記載
- 根本原因（Node.js runtime vs Edge Runtime 非互換）を記載
- 回避策（`MOCK_USER_EMAIL` 設定）・対応方針（Clerk 対応待ち）を記載

### `docs/testing.md`
- 「E2E テスト（Playwright MCP）」セクションを追加
- T127 制約・MOCK 要否の判断表・テストユーザー一覧・Playwright MCP 向け指示テンプレートを記載

## 関連

- Related to #119（Clerk 対応完了まで Issue はオープンのまま維持）
- 参考: [clerk/javascript#7705](https://github.com/clerk/javascript/issues/7705)

🤖 Generated with [Claude Code](https://claude.com/claude-code)