### PR TITLE
[T123] VIEWER ロールのヘッダーから「日報作成」リンクを非表示にする

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,12 +26,14 @@ export async function Header() {
             >
               月次ビュー
             </Link>
-            <Link
-              href="/reports/new"
-              className="whitespace-nowrap text-sm text-zinc-600 hover:text-zinc-900"
-            >
-              日報作成
-            </Link>
+            {session?.user?.role !== "VIEWER" && (
+              <Link
+                href="/reports/new"
+                className="whitespace-nowrap text-sm text-zinc-600 hover:text-zinc-900"
+              >
+                日報作成
+              </Link>
+            )}
             {session?.user?.role === "ADMIN" && (
               <Link
                 href="/admin/users"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,7 +26,7 @@ export async function Header() {
             >
               月次ビュー
             </Link>
-            {session?.user?.role !== "VIEWER" && (
+            {(session?.user?.role === "ADMIN" || session?.user?.role === "MEMBER") && (
               <Link
                 href="/reports/new"
                 className="whitespace-nowrap text-sm text-zinc-600 hover:text-zinc-900"


### PR DESCRIPTION
## 概要

VIEWER ロールのユーザーでログイン時、ヘッダーに「日報作成」リンクが表示されていた不具合を修正。

## 変更内容

- `src/components/Header.tsx`: 「日報作成」リンクを `session?.user?.role !== "VIEWER"` の条件で囲み、VIEWER ロールでは非表示にする

## 動作確認

| ロール | 日報作成 | ユーザー管理 |
|--------|---------|------------|
| VIEWER（nankotsu） | 非表示 ✅ | 非表示 ✅ |
| MEMBER（tsukune） | 表示 ✅ | 非表示 ✅ |
| ADMIN（bonjiri） | 表示 ✅ | 表示 ✅ |

## 関連

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)