### PR TITLE
fix: /api/reports を proxy.ts の isPublicRoute に追加する

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -103,7 +103,7 @@ const userId = session?.user?.id;
 |------|------|------|
 | `/login` | 不要 | Clerk のサインインページ |
 | `/auth-error` | 不要 | 認証エラー表示ページ |
-| `/api/reports` | 不要 | 外部連携用 REST API。Clerk 認証ではなく APIキー認証（`Authorization: Bearer`）で認可する |
+| `/api/reports/**` | 不要 | 外部連携用 REST API。`/api/reports` 本体および配下のサブパスは、Clerk 認証ではなく APIキー認証（`Authorization: Bearer`）で認可する |
 | その他全パス | **必須** | 未認証なら Clerk が `/login` へリダイレクト |
 
 ---

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -103,6 +103,7 @@ const userId = session?.user?.id;
 |------|------|------|
 | `/login` | 不要 | Clerk のサインインページ |
 | `/auth-error` | 不要 | 認証エラー表示ページ |
+| `/api/reports` | 不要 | 外部連携用 REST API。Clerk 認証ではなく APIキー認証（`Authorization: Bearer`）で認可する |
 | その他全パス | **必須** | 未認証なら Clerk が `/login` へリダイレクト |
 
 ---

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -44,8 +44,10 @@ const BONJIRI_NAME  = "bonjiri";
 
 // ---- tsukune: 日報・コメント・ユーザー分離テストのメインユーザー（MEMBER） ----
 // 今日を含む過去7日の日報あり。複数ユーザーからのコメントあり。
-const TSUKUNE_EMAIL = "tsukune@example.com";
-const TSUKUNE_NAME  = "tsukune";
+// apiKey を固定値で設定（REST API 動作確認用）
+const TSUKUNE_EMAIL  = "tsukune@example.com";
+const TSUKUNE_NAME   = "tsukune";
+const TSUKUNE_APIKEY = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
 const TSUKUNE_REPORTS = [
   { daysAgo: 0, workContent: "機能実装：ログイン画面のバリデーション追加",       tomorrowPlan: "日報詳細ページのUI実装を開始する",       notes: "特に問題なし。チームの連携がスムーズでよかった。" },
   { daysAgo: 1, workContent: "バグ修正：日報一覧が正しく表示されない問題を修正", tomorrowPlan: "コメント機能のAPI実装を進める",           notes: "" },
@@ -100,13 +102,13 @@ async function upsertClerkUser(email: string): Promise<string> {
   return created.id;
 }
 
-async function upsertUser(params: { email: string; name: string; role: Role; isActive: boolean }) {
-  const { email, name, role, isActive } = params;
+async function upsertUser(params: { email: string; name: string; role: Role; isActive: boolean; apiKey?: string }) {
+  const { email, name, role, isActive, apiKey } = params;
   const clerkId = await upsertClerkUser(email);
   return prisma.user.upsert({
     where: { email },
-    update: { name, role, isActive, clerkId },
-    create: { email, name, role, isActive, clerkId },
+    update: { name, role, isActive, clerkId, apiKey: apiKey ?? null },
+    create: { email, name, role, isActive, clerkId, apiKey: apiKey ?? null },
   });
 }
 
@@ -119,7 +121,7 @@ async function main() {
   // ユーザーを upsert（ロール・isActive をシード定義にリセット）
   const [bonjiri, tsukune, tebasaki, nankotsu, , torikawa] = await Promise.all([
     upsertUser({ email: BONJIRI_EMAIL,  name: BONJIRI_NAME,  role: "ADMIN",  isActive: true  }),
-    upsertUser({ email: TSUKUNE_EMAIL,  name: TSUKUNE_NAME,  role: "MEMBER", isActive: true  }),
+    upsertUser({ email: TSUKUNE_EMAIL,  name: TSUKUNE_NAME,  role: "MEMBER", isActive: true,  apiKey: TSUKUNE_APIKEY }),
     upsertUser({ email: TEBASAKI_EMAIL, name: TEBASAKI_NAME, role: "MEMBER", isActive: true  }),
     upsertUser({ email: NANKOTSU_EMAIL, name: NANKOTSU_NAME, role: "VIEWER", isActive: true  }),
     upsertUser({ email: SUNAGIMO_EMAIL, name: SUNAGIMO_NAME, role: "MEMBER", isActive: false }),
@@ -169,7 +171,7 @@ async function main() {
   console.log("\nSeed completed successfully!");
   console.log("\n--- Users ---");
   console.log(`  ${BONJIRI_EMAIL}  (ADMIN,  active)   — 管理操作の実行者`);
-  console.log(`  ${TSUKUNE_EMAIL}  (MEMBER, active)   — 日報7件・コメントあり`);
+  console.log(`  ${TSUKUNE_EMAIL}  (MEMBER, active)   — 日報7件・コメントあり・apiKey: ${TSUKUNE_APIKEY}`);
   console.log(`  ${TEBASAKI_EMAIL} (MEMBER, active)   — 日報7件・コメントあり`);
   console.log(`  ${NANKOTSU_EMAIL} (VIEWER, active)   — コメントあり`);
   console.log(`  ${SUNAGIMO_EMAIL} (MEMBER, inactive) — 認証エラーリダイレクト確認用`);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-const isPublicRoute = createRouteMatcher(["/login(.*)", "/auth-error"]);
+const isPublicRoute = createRouteMatcher(["/login(.*)", "/auth-error", "/api/reports(.*)"]);
 
 export default clerkMiddleware(async (auth, request) => {
   // 非本番環境: MOCK_USER_ID / MOCK_USER_EMAIL が設定されている場合はバイパス


### PR DESCRIPTION
## Summary

- `src/proxy.ts` の `isPublicRoute` に `/api/reports(.*)` を追加し、Clerk middleware による認証チェックをバイパスするよう修正
- 本番環境で外部クライアントの Bearer トークン付きリクエストが Clerk middleware に弾かれる不具合を修正（ot-nemoto/daily-hub#145）
- `docs/auth.md` の「保護対象ルート」テーブルに `/api/reports` の扱いを追記
- `prisma/seed.ts` に `tsukune` の固定 apiKey を追加（REST API 動作確認用）

## Test plan

- [ ] `npm test` — 全 118 テスト通過を確認
- [ ] `npm run dev` 起動後、APIキーあり curl で 201、APIキーなし curl で 401 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)