### PR TITLE
[T140] README にバッジを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # daily-hub
 
+![CI](https://github.com/ot-nemoto/daily-hub/actions/workflows/ci.yml/badge.svg)
+![Version](https://img.shields.io/github/package-json/v/ot-nemoto/daily-hub)
+![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)
+![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)
+![Prisma](https://img.shields.io/badge/Prisma-7-2D3748?logo=prisma&logoColor=white)
+![Clerk](https://img.shields.io/badge/Clerk-Auth-6C47FF?logo=clerk&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?logo=tailwindcss&logoColor=white)
+
 チームメンバーが毎日の業務内容・翌日予定・所感を記録・共有する日報管理Webアプリ。
 
 ## 機能


### PR DESCRIPTION
## 概要

README.md のタイトル直下にバッジを追加し、CI ステータス・バージョン・技術スタックをひと目で確認できるようにする。

## 追加したバッジ

| バッジ | 内容 |
|-------|------|
| CI | GitHub Actions `ci.yml` の実ステータスと連動 |
| Version | `package.json` のバージョンを自動反映 |
| Next.js 16 | 技術スタック |
| TypeScript 6 | 技術スタック |
| Prisma 7 | 技術スタック |
| Clerk Auth | 技術スタック |
| Tailwind CSS 4 | 技術スタック |

## 関連 Issue

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)