### PR TITLE
[T141] develop → master の自動 PR 作成ワークフローを追加する

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -10,6 +10,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: auto-pr-develop-to-master
+  cancel-in-progress: false
+
 jobs:
   auto-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -102,7 +102,7 @@ jobs:
             gh pr create \
               --base master \
               --head develop \
-              --title "chore: develop → master $(date +'%Y-%m-%d')" \
+              --title "chore: develop → master $(TZ=Asia/Tokyo date +'%Y-%m-%d')" \
               --body-file /tmp/pr_body.md \
               --label "$LABEL"
             echo "✅ PR を新規作成しました（ラベル: $LABEL）"

--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: read
+  issues: write
 
 jobs:
   auto-pr:

--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -1,0 +1,115 @@
+name: Auto PR develop → master
+
+on:
+  schedule:
+    - cron: '0 21 * * *' # JST AM6:00 (UTC 21:00)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  auto-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check diff between develop and master
+        id: diff
+        run: |
+          git fetch origin
+          COUNT=$(git log origin/master..origin/develop --oneline | wc -l | tr -d ' ')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+            echo "差分あり: ${COUNT} コミット"
+          else
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+            echo "差分なし。スキップします。"
+          fi
+
+      - name: Determine bump label and build PR body
+        id: content
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABEL="bump:patch"
+          ISSUES_SECTION=""
+
+          # コミットメッセージから Issue 番号を抽出
+          ISSUE_NUMBERS=$(git log origin/master..origin/develop --format="%B" \
+            | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -u)
+
+          for NUM in $ISSUE_NUMBERS; do
+            ISSUE_DATA=$(gh issue view "$NUM" --json title,labels 2>/dev/null) || continue
+            ISSUE_TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
+            ISSUE_LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[].name')
+
+            ISSUES_SECTION="${ISSUES_SECTION}- #${NUM} ${ISSUE_TITLE}\n"
+
+            # enhancement ラベルがあれば bump:minor に昇格
+            if echo "$ISSUE_LABELS" | grep -q "^enhancement$"; then
+              LABEL="bump:minor"
+            fi
+          done
+
+          # Dependabot コミットが含まれる場合はログに記録（patch のまま）
+          if git log origin/master..origin/develop --format="%s" | grep -q "^chore(deps"; then
+            echo "Dependabot コミットを検出 → bump:patch"
+          fi
+
+          # PR 本文を生成
+          {
+            echo "## 概要"
+            echo ""
+            echo "develop ブランチの変更を master にマージします。"
+            echo ""
+            if [ -n "$ISSUES_SECTION" ]; then
+              echo "## 含まれる Issue"
+              echo ""
+              printf "%b" "$ISSUES_SECTION"
+            else
+              echo "## 含まれる変更"
+              echo ""
+              git log origin/master..origin/develop --oneline | head -10 | sed 's/^/- /'
+            fi
+            echo ""
+            echo "🤖 このPRは自動生成されました"
+          } > /tmp/pr_body.md
+
+          echo "label=$LABEL" >> "$GITHUB_OUTPUT"
+          echo "判定ラベル: $LABEL"
+
+      - name: Create or update PR
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LABEL="${{ steps.content.outputs.label }}"
+          EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
+
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --base master \
+              --head develop \
+              --title "chore: develop → master $(date +'%Y-%m-%d')" \
+              --body-file /tmp/pr_body.md \
+              --label "$LABEL"
+            echo "✅ PR を新規作成しました（ラベル: $LABEL）"
+          else
+            # 本文を更新
+            gh pr edit "$EXISTING_PR" --body-file /tmp/pr_body.md
+
+            # ラベルを差し替え
+            gh pr edit "$EXISTING_PR" --remove-label "bump:minor" 2>/dev/null || true
+            gh pr edit "$EXISTING_PR" --remove-label "bump:patch" 2>/dev/null || true
+            gh pr edit "$EXISTING_PR" --add-label "$LABEL"
+
+            echo "✅ PR #${EXISTING_PR} を更新しました（ラベル: $LABEL）"
+          fi


### PR DESCRIPTION
## 概要

毎日 JST AM6:00 に develop と master の差分を確認し、差分があれば自動で PR を作成・更新する GitHub Actions ワークフローを追加する。

## 処理フロー

1. develop と master の差分確認 → 差分なしはスキップ
2. コミットメッセージから `Closes #xxx` / `Fixes #xxx` で Issue 番号を抽出
3. Issue ラベルでバンプ種別を判定
   - `enhancement` が含まれる → `bump:minor`
   - `fix` / `testing` のみ / Dependabot → `bump:patch`
4. PR 未作成 → 新規作成＋ラベル付与
5. PR 作成済み → 本文・ラベル更新

## 変更ファイル

- `.github/workflows/auto-pr-to-master.yml`（新規追加）

## 関連 Issue

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)