### PR TITLE
[T143] GitHub Actions CI/CD フローを eval-hub 構成に合わせて更新する

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -39,7 +39,7 @@ jobs:
         id: content
         if: steps.diff.outputs.has_diff == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_PR_TOKEN }}
         run: |
           LABEL="bump:patch"
           ISSUES_SECTION=""
@@ -93,7 +93,7 @@ jobs:
       - name: Create or update PR
         if: steps.diff.outputs.has_diff == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_PR_TOKEN }}
         run: |
           LABEL="${{ steps.content.outputs.label }}"
           EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -36,5 +36,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }} [skip ci]"
           git push


### PR DESCRIPTION
## 概要

eval-hub リポジトリで動作確認済みの CI/CD 構成を daily-hub に移植する。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `.github/workflows/auto-pr-to-master.yml` | `GITHUB_TOKEN` → `AUTO_PR_TOKEN` に変更（2箇所）|
| `.github/workflows/bump-version.yml` | commit メッセージに `[skip ci]` を追加 |

## 変更理由

- `GITHUB_TOKEN` で作成した PR は CI がトリガーされない（GitHub の仕様）→ PAT（`AUTO_PR_TOKEN`）に変更
- bump コミットのプッシュで CI が `action_required`（0 jobs）になるのを `[skip ci]` で防止

## 関連 Issue

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)