### PR TITLE
fix: PR description の Closes #N もバンプラベル判定に反映する

### DIFF
--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -110,25 +110,37 @@ jobs:
           GH_TOKEN: ${{ secrets.AUTO_PR_TOKEN }}
         run: |
           LABEL="${{ steps.content.outputs.label }}"
-          EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
+          REPO="${{ github.repository }}"
+          OWNER="${{ github.repository_owner }}"
+          PR_BODY=$(cat /tmp/pr_body.md)
+
+          # 既存の open PR を REST API で確認（GraphQL 不使用）
+          EXISTING_PR=$(gh api "repos/$REPO/pulls?base=master&head=${OWNER}:develop&state=open" --jq '.[0].number // empty')
 
           if [ -z "$EXISTING_PR" ]; then
-            PR_URL=$(gh pr create \
-              --base master \
-              --head develop \
-              --title "chore: develop → master $(TZ=Asia/Tokyo date +'%Y-%m-%d')" \
-              --body-file /tmp/pr_body.md)
-            PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-            gh pr edit "$PR_NUMBER" --add-label "$LABEL"
+            # 新規 PR を REST API で作成
+            PR_NUMBER=$(gh api "repos/$REPO/pulls" \
+              --method POST \
+              --field title="chore: develop → master $(TZ=Asia/Tokyo date +'%Y-%m-%d')" \
+              --field body="$PR_BODY" \
+              --field head="develop" \
+              --field base="master" \
+              --jq '.number')
+            # ラベルを REST API で追加
+            gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+              --method POST \
+              --field "labels[]=$LABEL"
             echo "✅ PR を新規作成しました（ラベル: $LABEL）"
           else
-            # 本文を更新
-            gh pr edit "$EXISTING_PR" --body-file /tmp/pr_body.md
-
-            # ラベルを差し替え
-            gh pr edit "$EXISTING_PR" --remove-label "bump:minor" 2>/dev/null || true
-            gh pr edit "$EXISTING_PR" --remove-label "bump:patch" 2>/dev/null || true
-            gh pr edit "$EXISTING_PR" --add-label "$LABEL"
-
+            # 本文を REST API で更新
+            gh api "repos/$REPO/pulls/$EXISTING_PR" \
+              --method PATCH \
+              --field body="$PR_BODY"
+            # ラベルを REST API で差し替え
+            gh api "repos/$REPO/issues/$EXISTING_PR/labels/bump%3Aminor" --method DELETE 2>/dev/null || true
+            gh api "repos/$REPO/issues/$EXISTING_PR/labels/bump%3Apatch" --method DELETE 2>/dev/null || true
+            gh api "repos/$REPO/issues/$EXISTING_PR/labels" \
+              --method POST \
+              --field "labels[]=$LABEL"
             echo "✅ PR #${EXISTING_PR} を更新しました（ラベル: $LABEL）"
           fi

--- a/.github/workflows/auto-pr-to-master.yml
+++ b/.github/workflows/auto-pr-to-master.yml
@@ -47,8 +47,22 @@ jobs:
           # コミットメッセージから Issue 番号を抽出
           ISSUE_NUMBERS=$(git log origin/master..origin/develop --format="%B" \
             | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
+            | grep -oE '[0-9]+' || true)
+
+          # マージコミットの PR description からも Issue 番号を抽出
+          # （gh pr merge --merge は Closes #N を PR description にのみ記録するため）
+          PR_NUMBERS=$(git log origin/master..origin/develop --format="%s" \
+            | grep -oE 'pull request #[0-9]+' \
             | grep -oE '[0-9]+' \
-            | sort -u)
+            | sort -u || true)
+          for PR_NUM in $PR_NUMBERS; do
+            PR_CLOSES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUM}" --jq '.body // ""' 2>/dev/null \
+              | grep -oE '(Closes|Fixes|closes|fixes) #[0-9]+' \
+              | grep -oE '[0-9]+' || true)
+            ISSUE_NUMBERS="${ISSUE_NUMBERS} ${PR_CLOSES}"
+          done
+
+          ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | tr ' ' '\n' | grep -v '^$' | sort -u || true)
 
           for NUM in $ISSUE_NUMBERS; do
             ISSUE_DATA=$(gh issue view "$NUM" --json title,labels 2>/dev/null) || continue


### PR DESCRIPTION
## 概要

`auto-pr-to-master.yml` のバンプラベル判定を修正する。

`gh pr merge --merge` でマージした場合、`Closes #N` は PR description にのみ記録され、個々のコミットメッセージには含まれない。そのため `git log --format="%B"` だけでは Issue 番号を取得できず、`enhancement` ラベルを持つ Issue があっても常に `bump:patch` にフォールバックしていた。

## 変更内容

- マージコミットの件名（`%s`）から `pull request #N` パターンで PR 番号を抽出
- `gh api repos/.../pulls/{PR_NUM}` で各 PR の description を取得
- description 内の `Closes #N` / `Fixes #N` から Issue 番号を抽出
- コミットメッセージ由来の番号と統合して重複排除

## 関連

- Closes #174
- 参考: https://github.com/ot-nemoto/account-sql-generator/issues/48

🤖 このPRはClaude Codeにより作成されました