### PR TITLE
[T146] .env.local を廃止して .env に統一する

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,7 +137,7 @@ External Client
 ## 環境変数
 
 ```env
-# .env.local（ローカル開発・本番共通）
+# .env（ローカル開発・本番共通）
 DATABASE_URL="postgresql://..."   # Neon の接続プール URL（?pgbouncer=true&connection_limit=1 付き）
 DIRECT_URL="postgresql://..."     # Neon の直接接続 URL（prisma migrate 用）
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@
 npm install
 ```
 
-`.env.local` をプロジェクトルートに作成する（`.env` ではなく `.env.local` を使う）。環境変数の詳細は [`docs/architecture.md` — 環境変数](architecture.md#環境変数) を参照。
+`.env` をプロジェクトルートに作成する。環境変数の詳細は [`docs/architecture.md` — 環境変数](architecture.md#環境変数) を参照。
 
 ```env
 DATABASE_URL="postgresql://<user>:<password>@<host>-pooler.<region>.aws.neon.tech/<db>?sslmode=require&channel_binding=require&pgbouncer=true&connection_limit=1"

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "prisma/config";
 import * as dotenv from "dotenv";
 
 dotenv.config({ path: ".env" });
-dotenv.config({ path: ".env.local", override: true });
 
 export default defineConfig({
   schema: "prisma/schema.prisma",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,7 +12,6 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { config } from "dotenv";
 import { PrismaClient } from "../src/generated/prisma/client";
 
-config({ path: ".env.local" });
 config();
 
 const connectionString = process.env.DATABASE_URL;


### PR DESCRIPTION
## 概要

`.env` が空のまま実体が `.env.local` に記載されていたが、どちらも git 管理外のため `.env.local` を使う意味がない。`.env` に統一し不要な参照を取り除く。

## 変更内容

- `prisma.config.ts`: `.env.local` への参照を削除（`.env` のみに統一）
- `prisma/seed.ts`: `config({ path: ".env.local" })` を削除
- `docs/architecture.md`: 環境変数コメントを `.env` に更新
- `docs/development.md`: `.env` を使うよう案内を更新
- `.env.local` → `.env` へ内容を移行・`.env.local` を削除（ローカル作業）

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)