### PR TITLE
[T149] フォントを M_PLUS_1_Code に統一する（kintone-viewer 準拠）

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-mplus1code: var(--font-mplus1code), monospace;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,5 +21,4 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,7 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-mplus1code: var(--font-mplus1code), monospace;
+  --font-mplus1code: var(--font-mplus1code-base), monospace;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { M_PLUS_1_Code } from "next/font/google";
 import "./globals.css";
 
 const mPlus1Code = M_PLUS_1_Code({
-  variable: "--font-mplus1code",
+  variable: "--font-mplus1code-base",
   subsets: ["latin"],
   weight: ["400", "500", "700"],
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,12 @@
 import { ClerkProvider } from "@clerk/nextjs";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { M_PLUS_1_Code } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const mPlus1Code = M_PLUS_1_Code({
+  variable: "--font-mplus1code",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ["400", "500", "700"],
 });
 
 export const metadata: Metadata = {
@@ -26,7 +22,7 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="ja">
-        <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+        <body className={`${mPlus1Code.variable} font-mplus1code antialiased`}>{children}</body>
       </html>
     </ClerkProvider>
   );


### PR DESCRIPTION
## 概要

kintone-viewer に合わせ、フォントを `Geist` / `Geist_Mono` から `M_PLUS_1_Code` に変更。

## 変更内容

- `src/app/layout.tsx`: `Geist` / `Geist_Mono` を `M_PLUS_1_Code`（400/500/700）に置き換え
- `src/app/globals.css`: `@theme inline` の font 変数を `--font-mplus1code` に更新

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)