### PR TITLE
[T151] バッチ登録で同一ユーザーが重複作成される競合状態を修正

### DIFF
--- a/src/app/api/admin/reports/route.test.ts
+++ b/src/app/api/admin/reports/route.test.ts
@@ -199,6 +199,20 @@ describe("POST /api/admin/reports", () => {
       expect(json.results).toHaveLength(2);
     });
 
+    it("同一 userName を含む複数件で resolveOrCreateUserByName が1回だけ呼ばれる", async () => {
+      vi.mocked(upsertReportByAuthorId)
+        .mockResolvedValueOnce({ id: "report-1", status: "created" })
+        .mockResolvedValueOnce({ id: "report-2", status: "created" });
+
+      const items = [
+        { ...VALID_ITEM, date: "2026-06-01" },
+        { ...VALID_ITEM, date: "2026-06-02" },
+      ];
+      await POST(makeRequest(items, VALID_API_KEY));
+      expect(resolveOrCreateUserByName).toHaveBeenCalledTimes(1);
+      expect(resolveOrCreateUserByName).toHaveBeenCalledWith("山田太郎");
+    });
+
     it("notes が省略された場合でも 200 を返す", async () => {
       vi.mocked(upsertReportByAuthorId).mockResolvedValue({ id: "report-1", status: "created" });
 

--- a/src/app/api/admin/reports/route.test.ts
+++ b/src/app/api/admin/reports/route.test.ts
@@ -11,11 +11,12 @@ vi.mock("@/lib/prisma", () => ({
 }));
 
 vi.mock("@/lib/reports", () => ({
-  upsertReportForUserName: vi.fn(),
+  resolveOrCreateUserByName: vi.fn(),
+  upsertReportByAuthorId: vi.fn(),
 }));
 
 import { prisma } from "@/lib/prisma";
-import { upsertReportForUserName } from "@/lib/reports";
+import { resolveOrCreateUserByName, upsertReportByAuthorId } from "@/lib/reports";
 import { POST } from "./route";
 
 const VALID_API_KEY = "test-admin-key";
@@ -147,10 +148,11 @@ describe("POST /api/admin/reports", () => {
   describe("正常系", () => {
     beforeEach(() => {
       vi.mocked(prisma.user.findUnique).mockResolvedValue(ADMIN_USER as never);
+      vi.mocked(resolveOrCreateUserByName).mockResolvedValue({ id: "user-1" });
     });
 
     it("新規登録で created を返す", async () => {
-      vi.mocked(upsertReportForUserName).mockResolvedValue({ id: "report-1", status: "created" });
+      vi.mocked(upsertReportByAuthorId).mockResolvedValue({ id: "report-1", status: "created" });
 
       const res = await POST(makeRequest([VALID_ITEM], VALID_API_KEY));
       expect(res.status).toBe(200);
@@ -161,7 +163,7 @@ describe("POST /api/admin/reports", () => {
     });
 
     it("既存日報への upsert で updated を返す", async () => {
-      vi.mocked(upsertReportForUserName).mockResolvedValue({ id: "report-1", status: "updated" });
+      vi.mocked(upsertReportByAuthorId).mockResolvedValue({ id: "report-1", status: "updated" });
 
       const res = await POST(makeRequest([VALID_ITEM], VALID_API_KEY));
       expect(res.status).toBe(200);
@@ -169,12 +171,12 @@ describe("POST /api/admin/reports", () => {
       expect(json.results[0].status).toBe("updated");
     });
 
-    it("upsertReportForUserName を正しい引数で呼び出す", async () => {
-      vi.mocked(upsertReportForUserName).mockResolvedValue({ id: "report-1", status: "created" });
+    it("upsertReportByAuthorId を正しい引数で呼び出す", async () => {
+      vi.mocked(upsertReportByAuthorId).mockResolvedValue({ id: "report-1", status: "created" });
 
       await POST(makeRequest([VALID_ITEM], VALID_API_KEY));
-      expect(upsertReportForUserName).toHaveBeenCalledWith({
-        userName: "山田太郎",
+      expect(upsertReportByAuthorId).toHaveBeenCalledWith({
+        authorId: "user-1",
         date: new Date("2026-06-01T00:00:00.000Z"),
         workContent: "作業内容",
         tomorrowPlan: "明日の予定",
@@ -183,7 +185,7 @@ describe("POST /api/admin/reports", () => {
     });
 
     it("複数件を一括登録してすべての results を返す", async () => {
-      vi.mocked(upsertReportForUserName)
+      vi.mocked(upsertReportByAuthorId)
         .mockResolvedValueOnce({ id: "report-1", status: "created" })
         .mockResolvedValueOnce({ id: "report-2", status: "created" });
 
@@ -198,12 +200,12 @@ describe("POST /api/admin/reports", () => {
     });
 
     it("notes が省略された場合でも 200 を返す", async () => {
-      vi.mocked(upsertReportForUserName).mockResolvedValue({ id: "report-1", status: "created" });
+      vi.mocked(upsertReportByAuthorId).mockResolvedValue({ id: "report-1", status: "created" });
 
       const { notes: _, ...itemWithoutNotes } = VALID_ITEM;
       const res = await POST(makeRequest([itemWithoutNotes], VALID_API_KEY));
       expect(res.status).toBe(200);
-      expect(upsertReportForUserName).toHaveBeenCalledWith(
+      expect(upsertReportByAuthorId).toHaveBeenCalledWith(
         expect.objectContaining({ notes: "" }),
       );
     });

--- a/src/app/api/admin/reports/route.ts
+++ b/src/app/api/admin/reports/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { prisma } from "@/lib/prisma";
-import { upsertReportForUserName } from "@/lib/reports";
+import { resolveOrCreateUserByName, upsertReportByAuthorId } from "@/lib/reports";
 
 const ReportItemSchema = z.object({
   userName: z.string().min(1, "userName は必須です"),
@@ -60,11 +60,20 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // 5. 各レポートを処理
+  // 5. ユニークな userName を事前に順次解決（並列 create による重複ユーザー作成を防ぐ）
+  const uniqueUserNames = [...new Set(parsed.data.map((d) => d.userName))];
+  const userMap = new Map<string, string>();
+  for (const userName of uniqueUserNames) {
+    const resolved = await resolveOrCreateUserByName(userName);
+    userMap.set(userName, resolved.id);
+  }
+
+  // 6. 各レポートを処理
   const results = await Promise.all(
     parsed.data.map(async ({ userName, date, workContent, tomorrowPlan, notes }) => {
-      const { id, status } = await upsertReportForUserName({
-        userName,
+      const authorId = userMap.get(userName)!;
+      const { id, status } = await upsertReportByAuthorId({
+        authorId,
         date: new Date(`${date}T00:00:00.000Z`),
         workContent,
         tomorrowPlan,

--- a/src/lib/reports.ts
+++ b/src/lib/reports.ts
@@ -16,6 +16,30 @@ export async function resolveOrCreateUserByName(userName: string): Promise<{ id:
   });
 }
 
+export async function upsertReportByAuthorId(input: {
+  authorId: string;
+  date: Date;
+  workContent: string;
+  tomorrowPlan: string;
+  notes: string;
+}): Promise<{ id: string; status: "created" | "updated" }> {
+  const { authorId, date, workContent, tomorrowPlan, notes } = input;
+
+  const existing = await prisma.report.findFirst({
+    where: { authorId, date },
+    select: { id: true },
+  });
+
+  const report = await prisma.report.upsert({
+    where: { authorId_date: { authorId, date } },
+    create: { date, workContent, tomorrowPlan, notes, authorId },
+    update: { workContent, tomorrowPlan, notes },
+    select: { id: true },
+  });
+
+  return { id: report.id, status: existing ? "updated" : "created" };
+}
+
 export async function upsertReportForUserName(input: {
   userName: string;
   date: Date;
@@ -24,22 +48,8 @@ export async function upsertReportForUserName(input: {
   notes: string;
 }): Promise<{ id: string; status: "created" | "updated" }> {
   const { userName, date, workContent, tomorrowPlan, notes } = input;
-
   const targetUser = await resolveOrCreateUserByName(userName);
-
-  const existing = await prisma.report.findFirst({
-    where: { authorId: targetUser.id, date },
-    select: { id: true },
-  });
-
-  const report = await prisma.report.upsert({
-    where: { authorId_date: { authorId: targetUser.id, date } },
-    create: { date, workContent, tomorrowPlan, notes, authorId: targetUser.id },
-    update: { workContent, tomorrowPlan, notes },
-    select: { id: true },
-  });
-
-  return { id: report.id, status: existing ? "updated" : "created" };
+  return upsertReportByAuthorId({ authorId: targetUser.id, date, workContent, tomorrowPlan, notes });
 }
 
 export async function createReport(input: {


### PR DESCRIPTION
## Summary

- `POST /api/admin/reports` で同一 `userName` の複数件を登録すると、`Promise.all` による並列処理で `resolveOrCreateUserByName` が競合し、同一ユーザーが重複作成される race condition を修正
- `upsertReportByAuthorId`（authorId を直接受け取る関数）を `lib/reports.ts` に追加
- ルートハンドラでユニークな `userName` を事前に順次解決してから、レポートの upsert を並列処理するよう変更

Closes #209

## Test plan

- [ ] `vitest run src/app/api/admin/reports/route.test.ts` が全18件パスすること
- [ ] 同一 `userName` を含む複数件のバッチ登録でユーザーが1件だけ作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)