### PR TITLE
feat: UI改善（ヘッダー固定化・設定モーダル・アイコン・ページタイトル）

### DIFF
--- a/docs/e2e-scenarios.md
+++ b/docs/e2e-scenarios.md
@@ -50,6 +50,8 @@
 | 8 | `tsukune@example.com` | `/reports/new` を開く | アクティブメニュー | 「日報作成」がハイライトされる |
 | 9 | `bonjiri@example.com` | `/admin/users` を開く | アクティブメニュー | 「ユーザー管理」がハイライトされる |
 | 10 | `tsukune@example.com` | 非アクティブなメニューリンクにカーソルを当てる | ホバースタイル | カーソルを当てたリンクに背景色が付く |
+| 11 | `tsukune@example.com` | ページをスクロールする | ヘッダー固定 | スクロール中もヘッダーが画面上部に固定表示される |
+| 12 | `tsukune@example.com` | ヘッダー右端のギアアイコンをクリックする | 個人設定モーダル | 個人設定モーダルが中央に開く |
 
 ---
 
@@ -156,12 +158,14 @@
 
 | # | ユーザー | 手順 | 確認観点 | 期待値 |
 |---|---------|------|---------|-------|
-| 1 | `tsukune@example.com` | `/settings` にアクセスする | 現在の情報表示 | 現在の名前（tsukune）とメールアドレスが表示される |
-| 2 | `tsukune@example.com` | メールアドレスフィールドを確認する | 読み取り専用 | メールアドレスフィールドが変更不可（読み取り専用）になっている |
-| 3 | `tsukune@example.com` | 名前を「tsukune-updated」に変更して「保存」をクリックする | 名前変更の反映 | 保存成功フィードバックが表示され、ヘッダーの名前も更新される |
-| 4 | `tsukune@example.com` | 名前を「tsukune」に戻して「保存」をクリックする | 名前の復元 | 保存成功フィードバックが表示され、ヘッダーが「tsukune」に戻る |
-| 5 | `tsukune@example.com` | 名前を空にして「保存」をクリックする | 必須バリデーション | エラーが表示され保存されない |
-| 6 | `tsukune@example.com` | 101文字の名前を入力して「保存」をクリックする | 文字数バリデーション | エラーが表示され保存されない |
+| 1 | `tsukune@example.com` | ヘッダーのギアアイコンをクリックする | モーダル表示 | 個人設定モーダルが開き、現在の名前（tsukune）とメールアドレスが表示される |
+| 2 | `tsukune@example.com` | モーダルのメールアドレスフィールドを確認する | 読み取り専用 | メールアドレスフィールドが変更不可（読み取り専用）になっている |
+| 3 | `tsukune@example.com` | モーダルで名前を「tsukune-updated」に変更して「保存」をクリックする | 名前変更の反映 | 保存成功フィードバックが表示され、ヘッダーの名前も更新される |
+| 4 | `tsukune@example.com` | モーダルで名前を「tsukune」に戻して「保存」をクリックする | 名前の復元 | 保存成功フィードバックが表示され、ヘッダーが「tsukune」に戻る |
+| 5 | `tsukune@example.com` | モーダルで名前を空にして「保存」をクリックする | 必須バリデーション | エラーが表示され保存されない |
+| 6 | `tsukune@example.com` | モーダルで101文字の名前を入力して「保存」をクリックする | 文字数バリデーション | エラーが表示され保存されない |
+| 7 | `tsukune@example.com` | モーダルのオーバーレイをクリックする | モーダルを閉じる | モーダルが閉じる |
+| 8 | `tsukune@example.com` | モーダルを開いて Escape キーを押す | モーダルを閉じる | モーダルが閉じる |
 
 ---
 
@@ -169,14 +173,14 @@
 
 | # | ユーザー | 手順 | 確認観点 | 期待値 |
 |---|---------|------|---------|-------|
-| 1 | `tsukune@example.com` | `/settings` でAPIキー欄を確認する（シード後） | 既存キーの表示状態 | APIキーがマスク表示され、「再生成」「失効」ボタンのみ表示される（「表示」ボタンは表示されない） |
+| 1 | `tsukune@example.com` | ギアアイコンをクリックして個人設定モーダルを開き、APIキー欄を確認する（シード後） | 既存キーの表示状態 | APIキーがマスク表示され、「再生成」「失効」ボタンのみ表示される（「表示」ボタンは表示されない） |
 | 2 | `tsukune@example.com` | 「再生成」をクリックする | キーの更新 | 新しいキーが生成され、プレーンテキストで表示される |
 | 3 | `tsukune@example.com` | 「隠す」をクリックする | マスク表示への切り替え | APIキーがマスク表示に切り替わる |
 | 4 | `tsukune@example.com` | 「表示」をクリックする | プレーンテキスト表示への切り替え | APIキーがプレーンテキストで表示される（再生成直後のセッション内のみ） |
 | 5 | `tsukune@example.com` | ページをリロードする | リロード後のマスク表示 | マスク表示に戻り「表示」ボタンは表示されない |
 | 6 | `tsukune@example.com` | 「失効」をクリックする | キーの削除 | キーが削除され「生成する」ボタンに戻る |
 | 7 | `tsukune@example.com` | 「生成する」をクリックする | キーの新規生成 | キーが生成され、プレーンテキストで表示される |
-| 8 | `tebasaki@example.com` | `/settings` でAPIキー欄を確認する | ユーザー分離 | tsukune のキーは表示されない（tebasaki はキーなし） |
+| 8 | `tebasaki@example.com` | ギアアイコンをクリックして個人設定モーダルを開き、APIキー欄を確認する | ユーザー分離 | tsukune のキーは表示されない（tebasaki はキーなし） |
 
 ---
 
@@ -230,7 +234,7 @@ curl -X POST http://localhost:3000/api/reports \
 | 1 | `bonjiri@example.com` | `/admin/users` で「無効化」「削除」ボタン、ロール変更セレクトにカーソルを当てる | pointer カーソル | すべての要素で pointer カーソルが表示される |
 | 2 | `tsukune@example.com` | `/reports/new` で「日報を作成」「キャンセル」ボタンにカーソルを当てる | pointer カーソル | pointer カーソルが表示される |
 | 3 | `tsukune@example.com` | `/reports/[id]/edit` で「保存する」「キャンセル」ボタンにカーソルを当てる | pointer カーソル | pointer カーソルが表示される |
-| 4 | `tsukune@example.com` | `/settings` で各ボタン（保存する・生成する・再生成・失効・表示/隠す）にカーソルを当てる | pointer カーソル | pointer カーソルが表示される |
+| 4 | `tsukune@example.com` | 個人設定モーダルで各ボタン（保存する・生成する・再生成・失効・表示/隠す）にカーソルを当てる | pointer カーソル | pointer カーソルが表示される |
 | 5 | `tsukune@example.com` | `/reports/daily` のユーザーフィルタ select にカーソルを当てる | pointer カーソル | pointer カーソルが表示される |
 
 ---
@@ -242,4 +246,4 @@ curl -X POST http://localhost:3000/api/reports \
 | 1 | `tsukune@example.com` → `tebasaki@example.com` | tsukune でログインして日次ビューを確認後、ログアウトして tebasaki でログインする | 日報の分離 | tebasaki 視点では自分の日報と他ユーザーの日報が表示されるが、編集できるのは自分の日報のみ |
 | 2 | `tebasaki@example.com` | tsukune の日報編集 URL（`/reports/[id]/edit`）に直接アクセスする | 他ユーザーの編集ガード | `/reports/[id]` にリダイレクトされる |
 | 3 | `tsukune@example.com` → `tebasaki@example.com` | tsukune でコメントを投稿後、ログアウトして tebasaki でログインしてそのコメントを確認する | コメントの削除ボタン分離 | tebasaki には tsukune のコメントの削除ボタンが表示されない |
-| 4 | `tsukune@example.com` → `tebasaki@example.com` | tsukune の `/settings` で APIキーを確認後、ログアウトして tebasaki でログインし `/settings` を確認する | APIキーの分離 | tebasaki には tsukune の APIキーが表示されない |
+| 4 | `tsukune@example.com` → `tebasaki@example.com` | tsukune の個人設定モーダルで APIキーを確認後、ログアウトして tebasaki でログインし個人設定モーダルを確認する | APIキーの分離 | tebasaki には tsukune の APIキーが表示されない |

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="8" fill="#18181b"/>
+  <rect width="32" height="32" rx="8" fill="#3f3f46"/>
   <!-- document body -->
   <rect x="8" y="6" width="13" height="17" rx="2" fill="white" opacity="0.15"/>
   <rect x="8" y="6" width="13" height="17" rx="2" fill="none" stroke="white" stroke-width="1.5"/>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="8" fill="#3f3f46"/>
+  <rect width="32" height="32" rx="8" fill="#0ea5e9"/>
   <!-- document body -->
   <rect x="8" y="6" width="13" height="17" rx="2" fill="white" opacity="0.15"/>
   <rect x="8" y="6" width="13" height="17" rx="2" fill="none" stroke="white" stroke-width="1.5"/>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#18181b"/>
+  <text x="16" y="22" font-family="sans-serif" font-size="14" font-weight="700" fill="white" text-anchor="middle">DH</text>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="8" fill="#18181b"/>
-  <text x="16" y="22" font-family="sans-serif" font-size="14" font-weight="700" fill="white" text-anchor="middle">DH</text>
+  <!-- document body -->
+  <rect x="8" y="6" width="13" height="17" rx="2" fill="white" opacity="0.15"/>
+  <rect x="8" y="6" width="13" height="17" rx="2" fill="none" stroke="white" stroke-width="1.5"/>
+  <!-- lines -->
+  <line x1="11" y1="11" x2="18" y2="11" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+  <line x1="11" y1="14" x2="18" y2="14" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+  <line x1="11" y1="17" x2="15" y2="17" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+  <!-- check badge -->
+  <circle cx="22" cy="22" r="6" fill="#22c55e"/>
+  <polyline points="19,22 21,24 25,20" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/app/(auth)/login/[[...rest]]/page.tsx
+++ b/src/app/(auth)/login/[[...rest]]/page.tsx
@@ -1,7 +1,7 @@
 import { SignIn } from "@clerk/nextjs";
 
 export const metadata = {
-  title: "ログイン | Daily Hub",
+  title: "ログイン",
 };
 
 export default function LoginPage() {

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: "ユーザー管理" };
+
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,9 @@ const mPlus1Code = M_PLUS_1_Code({
 export const metadata: Metadata = {
   title: "Daily Hub",
   description: "チームの日報管理アプリ",
+  icons: {
+    icon: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,10 @@ const mPlus1Code = M_PLUS_1_Code({
 });
 
 export const metadata: Metadata = {
-  title: "Daily Hub",
+  title: {
+    default: "Daily Hub",
+    template: "%s | Daily Hub",
+  },
   description: "チームの日報管理アプリ",
   icons: {
     icon: "/favicon.svg",

--- a/src/app/reports/[id]/edit/page.tsx
+++ b/src/app/reports/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { ReportEditForm } from "./ReportEditForm";
 
 export const metadata = {
-  title: "日報編集 | Daily Hub",
+  title: "日報編集",
 };
 
 export default async function ReportEditPage({

--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -3,6 +3,13 @@ import { notFound } from "next/navigation";
 
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const report = await prisma.report.findUnique({ where: { id }, select: { date: true, author: { select: { name: true } } } });
+  if (!report) return { title: "日報詳細" };
+  return { title: `${report.date} ${report.author.name}` };
+}
 import { CommentDeleteButton } from "./CommentDeleteButton";
 import { CommentForm } from "./CommentForm";
 

--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -4,12 +4,7 @@ import { notFound } from "next/navigation";
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
-export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const report = await prisma.report.findUnique({ where: { id }, select: { date: true, author: { select: { name: true } } } });
-  if (!report) return { title: "日報詳細" };
-  return { title: `${report.date} ${report.author.name}` };
-}
+export const metadata = { title: "日報詳細" };
 import { CommentDeleteButton } from "./CommentDeleteButton";
 import { CommentForm } from "./CommentForm";
 

--- a/src/app/reports/daily/page.tsx
+++ b/src/app/reports/daily/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: "日次ビュー" };
+
 import { getSession } from "@/lib/auth";
 import { formatDateJa, isValidDate, today } from "@/lib/dateUtils";
 import { prisma } from "@/lib/prisma";

--- a/src/app/reports/monthly/page.tsx
+++ b/src/app/reports/monthly/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: "月次ビュー" };
+
 import { getSession } from "@/lib/auth";
 import { currentMonth, formatMonthJa, isValidDate, monthRange } from "@/lib/dateUtils";
 import { prisma } from "@/lib/prisma";

--- a/src/app/reports/new/page.tsx
+++ b/src/app/reports/new/page.tsx
@@ -4,7 +4,7 @@ import { getSession } from "@/lib/auth";
 import { ReportNewForm } from "./ReportNewForm";
 
 export const metadata = {
-  title: "日報作成 | Daily Hub",
+  title: "日報作成",
 };
 
 export default async function ReportNewPage() {

--- a/src/app/reports/status/page.tsx
+++ b/src/app/reports/status/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: "提出状況" };
+
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { type Period, StatusFilter } from "./StatusFilter";

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,31 +1,5 @@
-import { Header } from "@/components/Header";
-import { getSession } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
-import { SettingsForm } from "./SettingsForm";
 
-export default async function SettingsPage() {
-  const session = await getSession({ redirectOnInactive: true });
-  if (!session?.user) redirect("/login");
-
-  const dbUser = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { email: true, apiKey: true },
-  });
-
-  return (
-    <>
-      <Header />
-      <div className="min-h-screen bg-zinc-50 py-10">
-        <div className="mx-auto max-w-xl space-y-2 px-4">
-          <h1 className="text-lg font-bold text-zinc-900">個人設定</h1>
-          <SettingsForm
-            initialName={session.user.name}
-            email={dbUser?.email ?? ""}
-            hasInitialApiKey={dbUser?.apiKey !== null}
-          />
-        </div>
-      </div>
-    </>
-  );
+export default function SettingsPage() {
+  redirect("/reports/new");
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,7 +42,7 @@ export async function Header() {
             <SettingsModalTrigger
               name={session.user.name}
               email={dbUser?.email ?? ""}
-              hasInitialApiKey={dbUser?.apiKey !== null}
+              hasInitialApiKey={dbUser?.apiKey != null}
             />
           )}
           <SignOutButton className="shrink-0 cursor-pointer rounded-md border border-zinc-300 px-2.5 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,8 +20,12 @@ export async function Header() {
     <header className="sticky top-0 z-10 border-b border-zinc-200 bg-white">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
         <div className="flex items-center gap-3 sm:gap-6">
-          <Link href="/reports/new" className="shrink-0 text-sm font-bold text-zinc-900">
-            Daily Hub
+          <Link href="/reports/new" className="shrink-0 flex items-center gap-1.5">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-6 w-6 shrink-0" aria-hidden="true">
+              <rect width="24" height="24" rx="6" fill="#18181b"/>
+              <text x="12" y="16.5" fontFamily="sans-serif" fontSize="10" fontWeight="700" fill="white" textAnchor="middle">DH</text>
+            </svg>
+            <span className="text-sm font-bold text-zinc-900">Daily Hub</span>
           </Link>
           <nav className="flex items-center gap-2 sm:gap-4">
             <NavLinks role={session?.user?.role} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,7 @@ export async function Header() {
   const session = await getSession({ redirectOnInactive: true });
 
   return (
-    <header className="border-b border-zinc-200 bg-white">
+    <header className="sticky top-0 z-10 border-b border-zinc-200 bg-white">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
         <div className="flex items-center gap-3 sm:gap-6">
           <Link href="/reports/new" className="shrink-0 text-sm font-bold text-zinc-900">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,9 +21,15 @@ export async function Header() {
       <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
         <div className="flex items-center gap-3 sm:gap-6">
           <Link href="/reports/new" className="shrink-0 flex items-center gap-1.5">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-6 w-6 shrink-0" aria-hidden="true">
-              <rect width="24" height="24" rx="6" fill="#18181b"/>
-              <text x="12" y="16.5" fontFamily="sans-serif" fontSize="10" fontWeight="700" fill="white" textAnchor="middle">DH</text>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" className="h-7 w-7 shrink-0" aria-hidden="true">
+              <rect width="32" height="32" rx="8" fill="#18181b"/>
+              <rect x="8" y="6" width="13" height="17" rx="2" fill="white" opacity="0.15"/>
+              <rect x="8" y="6" width="13" height="17" rx="2" fill="none" stroke="white" strokeWidth="1.5"/>
+              <line x1="11" y1="11" x2="18" y2="11" stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
+              <line x1="11" y1="14" x2="18" y2="14" stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
+              <line x1="11" y1="17" x2="15" y2="17" stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
+              <circle cx="22" cy="22" r="6" fill="#22c55e"/>
+              <polyline points="19,22 21,24 25,20" fill="none" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
             <span className="text-sm font-bold text-zinc-900">Daily Hub</span>
           </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,7 @@ export async function Header() {
         <div className="flex items-center gap-3 sm:gap-6">
           <Link href="/reports/new" className="shrink-0 flex items-center gap-1.5">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" className="h-7 w-7 shrink-0" aria-hidden="true">
-              <rect width="32" height="32" rx="8" fill="#3f3f46"/>
+              <rect width="32" height="32" rx="8" fill="#0ea5e9"/>
               <rect x="8" y="6" width="13" height="17" rx="2" fill="white" opacity="0.15"/>
               <rect x="8" y="6" width="13" height="17" rx="2" fill="none" stroke="white" strokeWidth="1.5"/>
               <line x1="11" y1="11" x2="18" y2="11" stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,20 @@
 import Link from "next/link";
 
 import { getSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 import { NavLinks } from "./NavLinks";
+import { SettingsModalTrigger } from "./SettingsModalTrigger";
 import { SignOutButton } from "./SignOutButton";
 
 export async function Header() {
   const session = await getSession({ redirectOnInactive: true });
+
+  const dbUser = session?.user
+    ? await prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: { email: true, apiKey: true },
+      })
+    : null;
 
   return (
     <header className="sticky top-0 z-10 border-b border-zinc-200 bg-white">
@@ -20,12 +29,11 @@ export async function Header() {
         </div>
         <div className="flex items-center gap-2 sm:gap-3">
           {session?.user?.name && (
-            <Link
-              href="/settings"
-              className="hidden text-sm text-zinc-500 hover:text-zinc-900 sm:inline"
-            >
-              {session.user.name}
-            </Link>
+            <SettingsModalTrigger
+              name={session.user.name}
+              email={dbUser?.email ?? ""}
+              hasInitialApiKey={dbUser?.apiKey !== null}
+            />
           )}
           <SignOutButton className="shrink-0 cursor-pointer rounded-md border border-zinc-300 px-2.5 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50" />
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,7 @@ export async function Header() {
         <div className="flex items-center gap-3 sm:gap-6">
           <Link href="/reports/new" className="shrink-0 flex items-center gap-1.5">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" className="h-7 w-7 shrink-0" aria-hidden="true">
-              <rect width="32" height="32" rx="8" fill="#18181b"/>
+              <rect width="32" height="32" rx="8" fill="#3f3f46"/>
               <rect x="8" y="6" width="13" height="17" rx="2" fill="white" opacity="0.15"/>
               <rect x="8" y="6" width="13" height="17" rx="2" fill="none" stroke="white" strokeWidth="1.5"/>
               <line x1="11" y1="11" x2="18" y2="11" stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
@@ -31,7 +31,7 @@ export async function Header() {
               <circle cx="22" cy="22" r="6" fill="#22c55e"/>
               <polyline points="19,22 21,24 25,20" fill="none" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
-            <span className="text-sm font-bold text-zinc-900">Daily Hub</span>
+            <span className="text-base font-bold text-zinc-900">Daily Hub</span>
           </Link>
           <nav className="flex items-center gap-2 sm:gap-4">
             <NavLinks role={session?.user?.role} />

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { SettingsForm } from "@/app/settings/SettingsForm";
+
+type Props = {
+  initialName: string;
+  email: string;
+  hasInitialApiKey: boolean;
+  onClose: () => void;
+};
+
+export function SettingsModal({ initialName, email, hasInitialApiKey, onClose }: Props) {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label="個人設定"
+    >
+      {/* オーバーレイ */}
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      {/* ダイアログ本体 */}
+      <div className="relative z-10 mx-4 w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-xl bg-zinc-50 shadow-xl">
+        <div className="flex items-center justify-between border-b border-zinc-200 bg-white px-6 py-4 rounded-t-xl">
+          <h2 className="text-base font-bold text-zinc-900">個人設定</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            className="rounded-md p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+            </svg>
+          </button>
+        </div>
+        <div className="p-6">
+          <SettingsForm
+            initialName={initialName}
+            email={email}
+            hasInitialApiKey={hasInitialApiKey}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -25,7 +25,7 @@ export function SettingsModal({ initialName, email, hasInitialApiKey, onClose }:
       className="fixed inset-0 z-50 flex items-center justify-center"
       role="dialog"
       aria-modal="true"
-      aria-label="個人設定"
+      aria-labelledby="settings-dialog-title"
     >
       {/* オーバーレイ */}
       <div
@@ -36,7 +36,7 @@ export function SettingsModal({ initialName, email, hasInitialApiKey, onClose }:
       {/* ダイアログ本体 */}
       <div className="relative z-10 mx-4 w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-xl bg-zinc-50 shadow-xl">
         <div className="flex items-center justify-between border-b border-zinc-200 bg-white px-6 py-4 rounded-t-xl">
-          <h2 className="text-base font-bold text-zinc-900">個人設定</h2>
+          <h2 id="settings-dialog-title" className="text-base font-bold text-zinc-900">個人設定</h2>
           <button
             type="button"
             onClick={onClose}

--- a/src/components/SettingsModalTrigger.tsx
+++ b/src/components/SettingsModalTrigger.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+
+import { SettingsModal } from "./SettingsModal";
+
+type Props = {
+  name: string;
+  email: string;
+  hasInitialApiKey: boolean;
+};
+
+export function SettingsModalTrigger({ name, email, hasInitialApiKey }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="hidden text-sm text-zinc-500 hover:text-zinc-900 sm:inline"
+      >
+        {name}
+      </button>
+      {open && (
+        <SettingsModal
+          initialName={name}
+          email={email}
+          hasInitialApiKey={hasInitialApiKey}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/SettingsModalTrigger.tsx
+++ b/src/components/SettingsModalTrigger.tsx
@@ -15,13 +15,19 @@ export function SettingsModalTrigger({ name, email, hasInitialApiKey }: Props) {
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="hidden cursor-pointer text-sm text-zinc-500 hover:text-zinc-900 sm:inline"
-      >
-        {name}
-      </button>
+      <div className="hidden items-center gap-1.5 sm:flex">
+        <span className="text-sm text-zinc-500">{name}</span>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label="個人設定を開く"
+          className="cursor-pointer rounded-md p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
+          </svg>
+        </button>
+      </div>
       {open && (
         <SettingsModal
           initialName={name}

--- a/src/components/SettingsModalTrigger.tsx
+++ b/src/components/SettingsModalTrigger.tsx
@@ -18,7 +18,7 @@ export function SettingsModalTrigger({ name, email, hasInitialApiKey }: Props) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="hidden text-sm text-zinc-500 hover:text-zinc-900 sm:inline"
+        className="hidden cursor-pointer text-sm text-zinc-500 hover:text-zinc-900 sm:inline"
       >
         {name}
       </button>

--- a/src/components/SettingsModalTrigger.tsx
+++ b/src/components/SettingsModalTrigger.tsx
@@ -15,8 +15,8 @@ export function SettingsModalTrigger({ name, email, hasInitialApiKey }: Props) {
 
   return (
     <>
-      <div className="hidden items-center gap-1.5 sm:flex">
-        <span className="text-sm text-zinc-500">{name}</span>
+      <div className="flex items-center gap-1.5">
+        <span className="hidden text-sm text-zinc-500 sm:inline">{name}</span>
         <button
           type="button"
           onClick={() => setOpen(true)}


### PR DESCRIPTION
## Summary
- ヘッダーを `sticky` 固定化してスクロール時も常に表示されるようにした (#239)
- 個人設定をモーダル化し、ギアアイコンクリックで開けるようにした (#240)
- SVG favicon とヘッダーロゴ（ドキュメント＋チェック）を作成した (#241)
- 全ページにブラウザタブ用タイトルを設定した (#241)
- `/settings` 直接アクセスは `/reports/new` にリダイレクト

## Test plan
- [ ] スクロール時にヘッダーが固定表示される
- [ ] ヘッダーのギアアイコンをクリックすると個人設定モーダルが開く
- [ ] モーダル内で名前変更・APIキー操作が正常に動作する
- [ ] ブラウザタブに各ページ名が表示される
- [ ] favicon が表示される

Closes #239
Closes #240
Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)