### PR TITLE
feat: アプリアイコンをVノッチ鳥居デザインに変更

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,13 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="8" fill="#0ea5e9"/>
-  <!-- document body -->
-  <rect x="8" y="6" width="13" height="17" rx="2" fill="white" opacity="0.15"/>
-  <rect x="8" y="6" width="13" height="17" rx="2" fill="none" stroke="white" stroke-width="1.5"/>
-  <!-- lines -->
-  <line x1="11" y1="11" x2="18" y2="11" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
-  <line x1="11" y1="14" x2="18" y2="14" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
-  <line x1="11" y1="17" x2="15" y2="17" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
-  <!-- check badge -->
-  <circle cx="22" cy="22" r="6" fill="#22c55e"/>
-  <polyline points="19,22 21,24 25,20" fill="none" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="11" y1="10" x2="8"  y2="29" stroke="black" stroke-width="2"   stroke-linecap="round"/>
+  <line x1="21" y1="10" x2="24" y2="29" stroke="black" stroke-width="2"   stroke-linecap="round"/>
+  <polyline points="4,10 13,10 16,5 19,10 28,10" fill="none" stroke="black" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="11" y1="16" x2="21" y2="16" stroke="black" stroke-width="1.8" stroke-linecap="round"/>
 </svg>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,14 +22,10 @@ export async function Header() {
         <div className="flex items-center gap-3 sm:gap-6">
           <Link href="/reports/new" className="shrink-0 flex items-center gap-1.5">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" className="h-7 w-7 shrink-0" aria-hidden="true">
-              <rect width="32" height="32" rx="8" fill="#0ea5e9"/>
-              <rect x="8" y="6" width="13" height="17" rx="2" fill="white" opacity="0.15"/>
-              <rect x="8" y="6" width="13" height="17" rx="2" fill="none" stroke="white" strokeWidth="1.5"/>
-              <line x1="11" y1="11" x2="18" y2="11" stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
-              <line x1="11" y1="14" x2="18" y2="14" stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
-              <line x1="11" y1="17" x2="15" y2="17" stroke="white" strokeWidth="1.5" strokeLinecap="round" opacity="0.7"/>
-              <circle cx="22" cy="22" r="6" fill="#22c55e"/>
-              <polyline points="19,22 21,24 25,20" fill="none" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+              <line x1="11" y1="10" x2="8"  y2="29" stroke="black" strokeWidth="2"   strokeLinecap="round"/>
+              <line x1="21" y1="10" x2="24" y2="29" stroke="black" strokeWidth="2"   strokeLinecap="round"/>
+              <polyline points="4,10 13,10 16,5 19,10 28,10" fill="none" stroke="black" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"/>
+              <line x1="11" y1="16" x2="21" y2="16" stroke="black" strokeWidth="1.8" strokeLinecap="round"/>
             </svg>
             <span className="text-base font-bold text-zinc-900">Daily Hub</span>
           </Link>


### PR DESCRIPTION
## Summary

- favicon および Header のアイコンを、開き柱＋Vノッチ鳥居デザインに変更
- 背景透過・黒線のシンプルなデザイン

## Test plan

- [ ] ブラウザのタブアイコン（favicon）が新デザインになっていることを確認
- [ ] メニュー左上のアイコンが新デザインになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)