### PR TITLE
[T178] 日報一覧に表示フィールド切り替えタブを追加する

### DIFF
--- a/src/app/reports/daily/DailyFilter.tsx
+++ b/src/app/reports/daily/DailyFilter.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 
+import { DisplayFieldTabs } from "@/components/DisplayFieldContext";
 import { isValidDate } from "@/lib/dateUtils";
 
 type Props = {
@@ -42,17 +43,20 @@ export function DailyFilter({ currentDate }: Props) {
         <label htmlFor="date" className="block text-sm font-medium text-zinc-700">
           日付
         </label>
-        <input
-          id="date"
-          type="date"
-          value={date}
-          onChange={(e) => handleDateChange(e.target.value)}
-          className={`mt-1 rounded-md border px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-1 ${
-            dateError
-              ? "border-red-500 focus:border-red-500 focus:ring-red-500"
-              : "border-zinc-300 focus:border-zinc-500 focus:ring-zinc-500"
-          }`}
-        />
+        <div className="mt-1 flex items-center gap-3">
+          <input
+            id="date"
+            type="date"
+            value={date}
+            onChange={(e) => handleDateChange(e.target.value)}
+            className={`rounded-md border px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-1 ${
+              dateError
+                ? "border-red-500 focus:border-red-500 focus:ring-red-500"
+                : "border-zinc-300 focus:border-zinc-500 focus:ring-zinc-500"
+            }`}
+          />
+          <DisplayFieldTabs />
+        </div>
         {dateError && <p className="mt-1 text-xs text-red-500">正しい日付を入力してください</p>}
       </div>
       {isPending && (

--- a/src/app/reports/daily/page.tsx
+++ b/src/app/reports/daily/page.tsx
@@ -1,5 +1,6 @@
 export const metadata = { title: "日次ビュー" };
 
+import { DisplayFieldProvider } from "@/components/DisplayFieldContext";
 import { ReportSearchList } from "@/components/ReportSearchList";
 import { getSession } from "@/lib/auth";
 import { formatDateJa, isValidDate, today } from "@/lib/dateUtils";
@@ -30,28 +31,30 @@ export default async function DailyViewPage({
   });
 
   return (
-    <div className="min-h-screen bg-zinc-50 py-10">
-      <div className="mx-auto max-w-3xl space-y-6 px-4">
-        <div className="rounded-lg bg-white p-6 shadow-sm">
-          <h1 className="mb-4 text-lg font-bold text-zinc-900">日次ビュー</h1>
-          <DailyFilter currentDate={date} />
-        </div>
+    <DisplayFieldProvider>
+      <div className="min-h-screen bg-zinc-50 py-10">
+        <div className="mx-auto max-w-3xl space-y-6 px-4">
+          <div className="rounded-lg bg-white p-6 shadow-sm">
+            <h1 className="mb-4 text-lg font-bold text-zinc-900">日次ビュー</h1>
+            <DailyFilter currentDate={date} />
+          </div>
 
-        <ReportSearchList
-          primary="authorName"
-          emptyMessage={`${formatDateJa(date)} の日報はありません`}
-          reports={reports.map((report) => ({
-            id: report.id,
-            date,
-            authorName: report.author.name,
-            workContent: report.workContent,
-            tomorrowPlan: report.tomorrowPlan,
-            notes: report.notes,
-            commentCount: report._count.comments,
-            isAuthor: session?.user?.id === report.authorId,
-          }))}
-        />
+          <ReportSearchList
+            primary="authorName"
+            emptyMessage={`${formatDateJa(date)} の日報はありません`}
+            reports={reports.map((report) => ({
+              id: report.id,
+              date,
+              authorName: report.author.name,
+              workContent: report.workContent,
+              tomorrowPlan: report.tomorrowPlan,
+              notes: report.notes,
+              commentCount: report._count.comments,
+              isAuthor: session?.user?.id === report.authorId,
+            }))}
+          />
+        </div>
       </div>
-    </div>
+    </DisplayFieldProvider>
   );
 }

--- a/src/app/reports/monthly/MonthlyFilter.tsx
+++ b/src/app/reports/monthly/MonthlyFilter.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState, useTransition } from "react";
 
+import { DisplayFieldTabs } from "@/components/DisplayFieldContext";
 import { isValidMonth } from "@/lib/dateUtils";
 
 type User = { id: string; name: string };
@@ -181,6 +182,8 @@ export function MonthlyFilter({ currentMonth, currentAuthorId, users }: Props) {
           </div>
         )}
       </div>
+
+      <DisplayFieldTabs />
 
       {isPending && (
         <div

--- a/src/app/reports/monthly/page.tsx
+++ b/src/app/reports/monthly/page.tsx
@@ -1,5 +1,6 @@
 export const metadata = { title: "月次ビュー" };
 
+import { DisplayFieldProvider } from "@/components/DisplayFieldContext";
 import { ReportSearchList } from "@/components/ReportSearchList";
 import { getSession } from "@/lib/auth";
 import { currentMonth, formatMonthJa, isValidDate, monthRange } from "@/lib/dateUtils";
@@ -47,28 +48,30 @@ export default async function MonthlyViewPage({
   ]);
 
   return (
-    <div className="min-h-screen bg-zinc-50 py-10">
-      <div className="mx-auto max-w-3xl space-y-6 px-4">
-        <div className="rounded-lg bg-white p-6 shadow-sm">
-          <h1 className="mb-4 text-lg font-bold text-zinc-900">月次ビュー</h1>
-          <MonthlyFilter currentMonth={displayMonth} currentAuthorId={authorId} users={users} />
-        </div>
+    <DisplayFieldProvider>
+      <div className="min-h-screen bg-zinc-50 py-10">
+        <div className="mx-auto max-w-3xl space-y-6 px-4">
+          <div className="rounded-lg bg-white p-6 shadow-sm">
+            <h1 className="mb-4 text-lg font-bold text-zinc-900">月次ビュー</h1>
+            <MonthlyFilter currentMonth={displayMonth} currentAuthorId={authorId} users={users} />
+          </div>
 
-        <ReportSearchList
-          primary="date"
-          emptyMessage={`${formatMonthJa(displayMonth)} の日報はありません`}
-          reports={reports.map((report) => ({
-            id: report.id,
-            date: report.date.toISOString().slice(0, 10),
-            authorName: report.author.name,
-            workContent: report.workContent,
-            tomorrowPlan: report.tomorrowPlan,
-            notes: report.notes,
-            commentCount: report._count.comments,
-            isAuthor: session?.user?.id === report.authorId,
-          }))}
-        />
+          <ReportSearchList
+            primary="date"
+            emptyMessage={`${formatMonthJa(displayMonth)} の日報はありません`}
+            reports={reports.map((report) => ({
+              id: report.id,
+              date: report.date.toISOString().slice(0, 10),
+              authorName: report.author.name,
+              workContent: report.workContent,
+              tomorrowPlan: report.tomorrowPlan,
+              notes: report.notes,
+              commentCount: report._count.comments,
+              isAuthor: session?.user?.id === report.authorId,
+            }))}
+          />
+        </div>
       </div>
-    </div>
+    </DisplayFieldProvider>
   );
 }

--- a/src/components/DisplayFieldContext.tsx
+++ b/src/components/DisplayFieldContext.tsx
@@ -34,7 +34,7 @@ export function useDisplayField(): DisplayFieldContextValue {
 export function DisplayFieldTabs() {
   const [field, setField] = useDisplayField();
   return (
-    <div role="group" aria-label="表示フィールド切り替え" className="flex gap-1">
+    <fieldset aria-label="表示フィールド切り替え" className="flex gap-1 border-none p-0 m-0">
       {TABS.map((tab) => (
         <button
           key={tab.key}
@@ -50,6 +50,6 @@ export function DisplayFieldTabs() {
           {tab.label}
         </button>
       ))}
-    </div>
+    </fieldset>
   );
 }

--- a/src/components/DisplayFieldContext.tsx
+++ b/src/components/DisplayFieldContext.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { createContext, type ReactNode, useContext, useState } from "react";
+
+export type DisplayField = "workContent" | "tomorrowPlan" | "notes";
+
+const TABS: { key: DisplayField; label: string }[] = [
+  { key: "workContent", label: "本日の作業" },
+  { key: "tomorrowPlan", label: "明日の予定" },
+  { key: "notes", label: "感想/課題/問題点" },
+];
+
+const DisplayFieldContext = createContext<[DisplayField, (f: DisplayField) => void]>([
+  "notes",
+  () => {},
+]);
+
+export function DisplayFieldProvider({ children }: { children: ReactNode }) {
+  const [field, setField] = useState<DisplayField>("notes");
+  return (
+    <DisplayFieldContext.Provider value={[field, setField]}>
+      {children}
+    </DisplayFieldContext.Provider>
+  );
+}
+
+export function useDisplayField() {
+  return useContext(DisplayFieldContext);
+}
+
+export function DisplayFieldTabs() {
+  const [field, setField] = useDisplayField();
+  return (
+    <div className="flex gap-1">
+      {TABS.map((tab) => (
+        <button
+          key={tab.key}
+          type="button"
+          onClick={() => setField(tab.key)}
+          className={`cursor-pointer rounded-md px-2 py-0.5 text-xs font-medium transition-colors ${
+            tab.key === field
+              ? "bg-zinc-900 text-white"
+              : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+          }`}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/DisplayFieldContext.tsx
+++ b/src/components/DisplayFieldContext.tsx
@@ -10,10 +10,9 @@ const TABS: { key: DisplayField; label: string }[] = [
   { key: "notes", label: "感想/課題/問題点" },
 ];
 
-const DisplayFieldContext = createContext<[DisplayField, (f: DisplayField) => void]>([
-  "notes",
-  () => {},
-]);
+type DisplayFieldContextValue = [DisplayField, (f: DisplayField) => void];
+
+const DisplayFieldContext = createContext<DisplayFieldContextValue | null>(null);
 
 export function DisplayFieldProvider({ children }: { children: ReactNode }) {
   const [field, setField] = useState<DisplayField>("notes");
@@ -24,8 +23,12 @@ export function DisplayFieldProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useDisplayField() {
-  return useContext(DisplayFieldContext);
+export function useDisplayField(): DisplayFieldContextValue {
+  const ctx = useContext(DisplayFieldContext);
+  if (!ctx) {
+    throw new Error("useDisplayField must be used within a DisplayFieldProvider");
+  }
+  return ctx;
 }
 
 export function DisplayFieldTabs() {

--- a/src/components/DisplayFieldContext.tsx
+++ b/src/components/DisplayFieldContext.tsx
@@ -34,11 +34,12 @@ export function useDisplayField(): DisplayFieldContextValue {
 export function DisplayFieldTabs() {
   const [field, setField] = useDisplayField();
   return (
-    <div className="flex gap-1">
+    <div role="group" aria-label="表示フィールド切り替え" className="flex gap-1">
       {TABS.map((tab) => (
         <button
           key={tab.key}
           type="button"
+          aria-pressed={tab.key === field}
           onClick={() => setField(tab.key)}
           className={`cursor-pointer rounded-md px-2 py-0.5 text-xs font-medium transition-colors ${
             tab.key === field

--- a/src/components/ReportSearchList.tsx
+++ b/src/components/ReportSearchList.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { useDisplayField } from "./DisplayFieldContext";
+import { type DisplayField, useDisplayField } from "./DisplayFieldContext";
 import { PendingLink } from "./PendingLink";
 
 export type SearchableReport = {
@@ -24,7 +24,7 @@ type Props = {
   emptyMessage: string;
 };
 
-const FIELD_LABELS: Record<string, string> = {
+const FIELD_LABELS: Record<DisplayField, string> = {
   workContent: "本日の作業",
   tomorrowPlan: "明日の予定",
   notes: "感想/課題/問題点",

--- a/src/components/ReportSearchList.tsx
+++ b/src/components/ReportSearchList.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import { useDisplayField } from "./DisplayFieldContext";
 import { PendingLink } from "./PendingLink";
 
 export type SearchableReport = {
@@ -23,6 +24,12 @@ type Props = {
   emptyMessage: string;
 };
 
+const FIELD_LABELS: Record<string, string> = {
+  workContent: "本日の作業",
+  tomorrowPlan: "明日の予定",
+  notes: "感想/課題/問題点",
+};
+
 function matches(report: SearchableReport, query: string, includeAuthor: boolean) {
   const q = query.toLowerCase();
   return (
@@ -35,6 +42,7 @@ function matches(report: SearchableReport, query: string, includeAuthor: boolean
 
 export function ReportSearchList({ reports, primary, emptyMessage }: Props) {
   const [query, setQuery] = useState("");
+  const [displayField] = useDisplayField();
 
   const includeAuthor = primary === "authorName";
   const trimmed = query.trim();
@@ -105,9 +113,11 @@ export function ReportSearchList({ reports, primary, emptyMessage }: Props) {
             <dl>
               <div>
                 <dt className="inline-block rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600">
-                  感想/課題/問題点
+                  {FIELD_LABELS[displayField]}
                 </dt>
-                <dd className="mt-0.5 whitespace-pre-wrap text-sm text-zinc-900">{report.notes}</dd>
+                <dd className="mt-0.5 whitespace-pre-wrap text-sm text-zinc-900">
+                  {report[displayField]}
+                </dd>
               </div>
             </dl>
           </div>


### PR DESCRIPTION
## Summary
- 日次・月次ビューのフィルター横に表示切り替えタブを追加（本日の作業 / 明日の予定 / 感想・課題・問題点）
- `DisplayFieldContext` で状態を共有し、フィルターコンポーネントとリストコンポーネント間でタブ切り替えを実現
- デフォルト表示は「感想/課題/問題点」

## Test plan
- [x] 日次ビュー: タブが日付入力の横に表示される
- [x] 月次ビュー: タブが月・ユーザー選択の横に表示される
- [x] タブ切り替えで各カードの表示フィールドが即座に切り替わる
- [x] 検索はタブ選択に関わらず全フィールドを対象に動作する
- [x] タブの並び順: 本日の作業 → 明日の予定 → 感想/課題/問題点

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)