### PR TITLE
[T281] DayOff Actions のロジックを src/lib に切り出す

### DIFF
--- a/src/app/day-off/actions.test.ts
+++ b/src/app/day-off/actions.test.ts
@@ -4,25 +4,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
 vi.mock("@/lib/auth", () => ({ getSession: vi.fn() }));
+vi.mock("@/lib/day-off", () => ({
+  createDayOff: vi.fn(),
+  deleteDayOff: vi.fn(),
+}));
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     user: { findUnique: vi.fn() },
-    dayOff: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
-      deleteMany: vi.fn(),
-    },
   },
 }));
 
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
+import { createDayOff, deleteDayOff } from "@/lib/day-off";
+import { ConflictError } from "@/lib/errors";
 import { prisma } from "@/lib/prisma";
 import { addDayOff, removeDayOff } from "./actions";
 
 const selfSession = { user: { id: "self-1", name: "自分", role: "MEMBER", isActive: true } };
 const adminSession = { user: { id: "admin-1", name: "管理者", role: "ADMIN", isActive: true } };
+const viewerSession = { user: { id: "viewer-1", name: "閲覧者", role: "VIEWER", isActive: true } };
 const validDate = "2026-06-10";
 
 describe("addDayOff", () => {
@@ -30,14 +32,14 @@ describe("addDayOff", () => {
 
   it("正常系: 自分の休日を登録する", async () => {
     vi.mocked(getSession).mockResolvedValue(selfSession as never);
-    vi.mocked(prisma.dayOff.findUnique).mockResolvedValue(null);
-    vi.mocked(prisma.dayOff.create).mockResolvedValue({} as never);
+    vi.mocked(createDayOff).mockResolvedValue(undefined);
 
     const result = await addDayOff({ date: validDate });
 
     expect(result).toEqual({});
-    expect(prisma.dayOff.create).toHaveBeenCalledWith({
-      data: { userId: "self-1", date: new Date("2026-06-10T00:00:00.000Z") },
+    expect(createDayOff).toHaveBeenCalledWith({
+      userId: "self-1",
+      date: new Date("2026-06-10T00:00:00.000Z"),
     });
     expect(revalidatePath).toHaveBeenCalledWith("/day-off");
   });
@@ -45,14 +47,14 @@ describe("addDayOff", () => {
   it("正常系: ADMIN が他ユーザーの休日を登録する", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: "other-1" } as never);
-    vi.mocked(prisma.dayOff.findUnique).mockResolvedValue(null);
-    vi.mocked(prisma.dayOff.create).mockResolvedValue({} as never);
+    vi.mocked(createDayOff).mockResolvedValue(undefined);
 
     const result = await addDayOff({ date: validDate, userId: "other-1" });
 
     expect(result).toEqual({});
-    expect(prisma.dayOff.create).toHaveBeenCalledWith({
-      data: { userId: "other-1", date: new Date("2026-06-10T00:00:00.000Z") },
+    expect(createDayOff).toHaveBeenCalledWith({
+      userId: "other-1",
+      date: new Date("2026-06-10T00:00:00.000Z"),
     });
   });
 
@@ -62,7 +64,16 @@ describe("addDayOff", () => {
     await addDayOff({ date: validDate });
 
     expect(redirect).toHaveBeenCalledWith("/login");
-    expect(prisma.dayOff.create).not.toHaveBeenCalled();
+    expect(createDayOff).not.toHaveBeenCalled();
+  });
+
+  it("異常系: VIEWER はエラーを返す", async () => {
+    vi.mocked(getSession).mockResolvedValue(viewerSession as never);
+
+    const result = await addDayOff({ date: validDate });
+
+    expect(result).toMatchObject({ error: "休日を登録する権限がありません" });
+    expect(createDayOff).not.toHaveBeenCalled();
   });
 
   it("異常系: 日付形式不正でエラーを返す", async () => {
@@ -71,17 +82,16 @@ describe("addDayOff", () => {
     const result = await addDayOff({ date: "invalid" });
 
     expect(result).toMatchObject({ error: expect.any(String) });
-    expect(prisma.dayOff.create).not.toHaveBeenCalled();
+    expect(createDayOff).not.toHaveBeenCalled();
   });
 
-  it("異常系: 重複日付でエラーを返す", async () => {
+  it("異常系: 重複日付で ConflictError が来たらエラーを返す", async () => {
     vi.mocked(getSession).mockResolvedValue(selfSession as never);
-    vi.mocked(prisma.dayOff.findUnique).mockResolvedValue({ id: "existing" } as never);
+    vi.mocked(createDayOff).mockRejectedValue(new ConflictError());
 
     const result = await addDayOff({ date: validDate });
 
     expect(result).toMatchObject({ error: "この日付はすでに休日として登録されています" });
-    expect(prisma.dayOff.create).not.toHaveBeenCalled();
   });
 
   it("異常系: 非ADMIN が他ユーザーの休日を登録しようとするとエラーを返す", async () => {
@@ -90,7 +100,7 @@ describe("addDayOff", () => {
     const result = await addDayOff({ date: validDate, userId: "other-1" });
 
     expect(result).toMatchObject({ error: "他のユーザーの休日を変更する権限がありません" });
-    expect(prisma.dayOff.create).not.toHaveBeenCalled();
+    expect(createDayOff).not.toHaveBeenCalled();
   });
 
   it("異常系: ADMIN が存在しないユーザーの休日を登録しようとするとエラーを返す", async () => {
@@ -100,7 +110,7 @@ describe("addDayOff", () => {
     const result = await addDayOff({ date: validDate, userId: "nonexistent" });
 
     expect(result).toMatchObject({ error: "指定されたユーザーが見つかりません" });
-    expect(prisma.dayOff.create).not.toHaveBeenCalled();
+    expect(createDayOff).not.toHaveBeenCalled();
   });
 });
 
@@ -109,13 +119,14 @@ describe("removeDayOff", () => {
 
   it("正常系: 自分の休日を削除する", async () => {
     vi.mocked(getSession).mockResolvedValue(selfSession as never);
-    vi.mocked(prisma.dayOff.deleteMany).mockResolvedValue({ count: 1 } as never);
+    vi.mocked(deleteDayOff).mockResolvedValue(undefined);
 
     const result = await removeDayOff({ date: validDate });
 
     expect(result).toEqual({});
-    expect(prisma.dayOff.deleteMany).toHaveBeenCalledWith({
-      where: { userId: "self-1", date: new Date("2026-06-10T00:00:00.000Z") },
+    expect(deleteDayOff).toHaveBeenCalledWith({
+      userId: "self-1",
+      date: new Date("2026-06-10T00:00:00.000Z"),
     });
     expect(revalidatePath).toHaveBeenCalledWith("/day-off");
   });
@@ -123,13 +134,14 @@ describe("removeDayOff", () => {
   it("正常系: ADMIN が他ユーザーの休日を削除する", async () => {
     vi.mocked(getSession).mockResolvedValue(adminSession as never);
     vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: "other-1" } as never);
-    vi.mocked(prisma.dayOff.deleteMany).mockResolvedValue({ count: 1 } as never);
+    vi.mocked(deleteDayOff).mockResolvedValue(undefined);
 
     const result = await removeDayOff({ date: validDate, userId: "other-1" });
 
     expect(result).toEqual({});
-    expect(prisma.dayOff.deleteMany).toHaveBeenCalledWith({
-      where: { userId: "other-1", date: new Date("2026-06-10T00:00:00.000Z") },
+    expect(deleteDayOff).toHaveBeenCalledWith({
+      userId: "other-1",
+      date: new Date("2026-06-10T00:00:00.000Z"),
     });
   });
 
@@ -139,7 +151,16 @@ describe("removeDayOff", () => {
     await removeDayOff({ date: validDate });
 
     expect(redirect).toHaveBeenCalledWith("/login");
-    expect(prisma.dayOff.deleteMany).not.toHaveBeenCalled();
+    expect(deleteDayOff).not.toHaveBeenCalled();
+  });
+
+  it("異常系: VIEWER はエラーを返す", async () => {
+    vi.mocked(getSession).mockResolvedValue(viewerSession as never);
+
+    const result = await removeDayOff({ date: validDate });
+
+    expect(result).toMatchObject({ error: "休日を解除する権限がありません" });
+    expect(deleteDayOff).not.toHaveBeenCalled();
   });
 
   it("異常系: 日付形式不正でエラーを返す", async () => {
@@ -148,7 +169,7 @@ describe("removeDayOff", () => {
     const result = await removeDayOff({ date: "2026/06/10" });
 
     expect(result).toMatchObject({ error: expect.any(String) });
-    expect(prisma.dayOff.deleteMany).not.toHaveBeenCalled();
+    expect(deleteDayOff).not.toHaveBeenCalled();
   });
 
   it("異常系: 非ADMIN が他ユーザーの休日を削除しようとするとエラーを返す", async () => {
@@ -157,18 +178,19 @@ describe("removeDayOff", () => {
     const result = await removeDayOff({ date: validDate, userId: "other-1" });
 
     expect(result).toMatchObject({ error: "他のユーザーの休日を変更する権限がありません" });
-    expect(prisma.dayOff.deleteMany).not.toHaveBeenCalled();
+    expect(deleteDayOff).not.toHaveBeenCalled();
   });
 
   it("正常系: userId が自分と同じなら MEMBER でも許可する", async () => {
     vi.mocked(getSession).mockResolvedValue(selfSession as never);
-    vi.mocked(prisma.dayOff.deleteMany).mockResolvedValue({ count: 0 } as never);
+    vi.mocked(deleteDayOff).mockResolvedValue(undefined);
 
     const result = await removeDayOff({ date: validDate, userId: "self-1" });
 
     expect(result).toEqual({});
-    expect(prisma.dayOff.deleteMany).toHaveBeenCalledWith({
-      where: { userId: "self-1", date: new Date("2026-06-10T00:00:00.000Z") },
+    expect(deleteDayOff).toHaveBeenCalledWith({
+      userId: "self-1",
+      date: new Date("2026-06-10T00:00:00.000Z"),
     });
   });
 });

--- a/src/app/day-off/actions.ts
+++ b/src/app/day-off/actions.ts
@@ -5,6 +5,8 @@ import { redirect } from "next/navigation";
 import { z } from "zod";
 
 import { getSession } from "@/lib/auth";
+import { createDayOff, deleteDayOff } from "@/lib/day-off";
+import { ConflictError } from "@/lib/errors";
 import { prisma } from "@/lib/prisma";
 
 const DateString = z
@@ -50,15 +52,10 @@ export async function addDayOff(input: {
 
   const date = new Date(`${parsed.data}T00:00:00.000Z`);
 
-  const existing = await prisma.dayOff.findUnique({
-    where: { userId_date: { userId: targetUserId, date } },
-  });
-  if (existing) return { error: "この日付はすでに休日として登録されています" };
-
   try {
-    await prisma.dayOff.create({ data: { userId: targetUserId, date } });
+    await createDayOff({ userId: targetUserId, date });
   } catch (error) {
-    if (error instanceof Error && "code" in error && (error as { code: string }).code === "P2002") {
+    if (error instanceof ConflictError) {
       return { error: "この日付はすでに休日として登録されています" };
     }
     throw error;
@@ -85,8 +82,7 @@ export async function removeDayOff(input: {
 
   const date = new Date(`${parsed.data}T00:00:00.000Z`);
 
-  // userId でスコープするため、未登録日付を指定しても 0 件削除で安全に無視される
-  await prisma.dayOff.deleteMany({ where: { userId: targetUserId, date } });
+  await deleteDayOff({ userId: targetUserId, date });
 
   revalidatePath("/day-off");
   return {};

--- a/src/lib/day-off.test.ts
+++ b/src/lib/day-off.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prisma } from "@/lib/prisma";
+
+import { ConflictError } from "./errors";
+import { createDayOff, deleteDayOff } from "./day-off";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    dayOff: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+const userId = "user-1";
+const date = new Date("2026-06-10T00:00:00.000Z");
+
+describe("createDayOff", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 休日を作成する", async () => {
+    vi.mocked(prisma.dayOff.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.dayOff.create).mockResolvedValue({} as never);
+
+    await expect(createDayOff({ userId, date })).resolves.toBeUndefined();
+    expect(prisma.dayOff.create).toHaveBeenCalledWith({ data: { userId, date } });
+  });
+
+  it("異常系: 重複する休日があれば ConflictError を throw する", async () => {
+    vi.mocked(prisma.dayOff.findUnique).mockResolvedValue({ id: "existing" } as never);
+
+    await expect(createDayOff({ userId, date })).rejects.toThrow(ConflictError);
+    expect(prisma.dayOff.create).not.toHaveBeenCalled();
+  });
+
+  it("異常系: DB の P2002 競合エラーを ConflictError に変換する", async () => {
+    vi.mocked(prisma.dayOff.findUnique).mockResolvedValue(null);
+    const p2002 = Object.assign(new Error("Unique constraint failed"), { code: "P2002" });
+    vi.mocked(prisma.dayOff.create).mockRejectedValue(p2002);
+
+    await expect(createDayOff({ userId, date })).rejects.toThrow(ConflictError);
+  });
+
+  it("異常系: P2002 以外のエラーは rethrow する", async () => {
+    vi.mocked(prisma.dayOff.findUnique).mockResolvedValue(null);
+    const unexpected = new Error("connection error");
+    vi.mocked(prisma.dayOff.create).mockRejectedValue(unexpected);
+
+    await expect(createDayOff({ userId, date })).rejects.toThrow("connection error");
+  });
+});
+
+describe("deleteDayOff", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("正常系: 休日を削除する", async () => {
+    vi.mocked(prisma.dayOff.deleteMany).mockResolvedValue({ count: 1 } as never);
+
+    await expect(deleteDayOff({ userId, date })).resolves.toBeUndefined();
+    expect(prisma.dayOff.deleteMany).toHaveBeenCalledWith({ where: { userId, date } });
+  });
+
+  it("正常系: 未登録日付でも 0 件削除で正常終了する", async () => {
+    vi.mocked(prisma.dayOff.deleteMany).mockResolvedValue({ count: 0 } as never);
+
+    await expect(deleteDayOff({ userId, date })).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/day-off.ts
+++ b/src/lib/day-off.ts
@@ -1,0 +1,27 @@
+import { prisma } from "@/lib/prisma";
+
+import { ConflictError } from "./errors";
+
+export async function createDayOff(input: { userId: string; date: Date }): Promise<void> {
+  const { userId, date } = input;
+
+  const existing = await prisma.dayOff.findUnique({
+    where: { userId_date: { userId, date } },
+  });
+  if (existing) throw new ConflictError("DayOff already exists for this date");
+
+  try {
+    await prisma.dayOff.create({ data: { userId, date } });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && (error as { code: string }).code === "P2002") {
+      throw new ConflictError("DayOff already exists for this date");
+    }
+    throw error;
+  }
+}
+
+export async function deleteDayOff(input: { userId: string; date: Date }): Promise<void> {
+  const { userId, date } = input;
+  // deleteMany で実装するため、未登録日付を指定しても 0 件削除で安全に無視される
+  await prisma.dayOff.deleteMany({ where: { userId, date } });
+}


### PR DESCRIPTION
## Summary

- `src/lib/day-off.ts` を新規作成し、`createDayOff` / `deleteDayOff` の DB 操作ロジックを集約
- `src/app/day-off/actions.ts` を認証・ロールチェック・バリデーション・エラー変換のみに整理
- `src/lib/day-off.test.ts` を新規作成（ユニットテスト 6 件）
- `src/app/day-off/actions.test.ts` を `@/lib/day-off` のモックに変更（15 件）

既存パターン（`src/lib/reports.ts` / `ConflictError`）に準拠。全テスト 193 件合格。

## Test plan

- [x] `npx vitest run` — 193 tests passed

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)