### PR TITLE
[T185] Vercelデプロイ時に prisma migrate deploy を自動実行する

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,9 +171,9 @@ Prisma 7 では URL の設定箇所が分離された。
 ```
 git push origin develop
   → Vercel が自動検知
-    → ビルド（next build）
+    → ビルド（vercel-build: prisma migrate deploy && next build）
       → Vercel にデプロイ
-        ※ マイグレーションは事前に手動で実行（prisma migrate deploy）
+        ※ マイグレーションは vercel-build スクリプトで自動実行
 
 git push origin master
   → GitHub Actions (release.yml) が起動

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,7 +60,10 @@ npm run dev
 
 ### マイグレーション
 
-マイグレーションは**常に手動で実行**する（ビルドスクリプトによる自動実行は行わない）。
+マイグレーションの実行タイミングは環境によって異なる。
+
+- **Vercel デプロイ時**: `vercel-build` スクリプト（`prisma migrate deploy && next build`）により自動実行
+- **ローカル開発**: 手動で実行する
 
 ```bash
 # スキーマ変更後に新しいマイグレーションを作成・適用
@@ -69,7 +72,7 @@ npx prisma migrate dev --name <migration-name>
 # 例：初回
 npx prisma migrate dev --name init
 
-# 本番・ステージング環境への適用（デプロイ前に手動実行）
+# 本番・ステージング環境への適用（Vercel 以外の環境で手動実行する場合）
 npx prisma migrate deploy
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -188,10 +188,8 @@ npx prisma generate
 ## デプロイ（Vercel）
 
 1. Vercel ダッシュボードで環境変数を設定（`DATABASE_URL`, `DIRECT_URL`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_SIGN_IN_URL`, `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL`）
-2. デプロイ前に**手動**でマイグレーションを適用する
+2. `develop` ブランチにプッシュすると自動デプロイ
 
-   ```bash
-   npx prisma migrate deploy
-   ```
-
-3. `main` ブランチにプッシュすると自動デプロイ（Build Command は `next build` のみ）
+   - Vercel は `package.json` の `vercel-build` スクリプトを優先して実行する
+   - `vercel-build` は `prisma migrate deploy && next build` を実行するため、マイグレーションは自動適用される
+   - Vercel ダッシュボードの Build Command 設定変更は不要

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "postinstall": "prisma generate",
     "prepare": "biome migrate --write",
     "build": "next build",
+    "vercel-build": "prisma migrate deploy && next build",
     "start": "next start",
     "lint": "biome lint .",
     "format": "biome format --write .",


### PR DESCRIPTION
## Summary

- `package.json` に `vercel-build` スクリプトを追加
- Vercel デプロイ時に `prisma migrate deploy && next build` が自動実行される
- Vercel ダッシュボードの設定変更は不要（`vercel-build` が `build` より優先されるため）
- ローカルの `npm run build` には影響なし
- `docs/development.md` のデプロイ手順を更新

## Test plan

- [ ] `develop` ブランチへのプッシュで Vercel のビルドログに `prisma migrate deploy` が含まれることを確認

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)